### PR TITLE
Bug fixed: Move the arrows to the top of the exercise page.

### DIFF
--- a/src/pages/CourseContent/styles.scss
+++ b/src/pages/CourseContent/styles.scss
@@ -55,8 +55,16 @@
 
   > .content > .arrow-row {
     padding: 32px 32px;
-    width: 80%;
+    // width: 80%;
+    position: absolute;
+    top: 173px;
+    width: 40%;
     display: flex;
     justify-content: space-between;
+    @include breakpoint-mobile {
+      width: 80%;
+      top: 142px;
+      position: absolute;
+    }
   }
 }


### PR DESCRIPTION
On the exercise, the page gave Right and left of the title add arrows and add position fixed.
![Screenshot from 2021-01-27 15-50-26](https://user-images.githubusercontent.com/43803182/105994179-4fe67e80-60cd-11eb-81b3-b1cc77107d18.png)
