### PR TITLE
[FIX] useEffect to set hiddenContent to hide on mount

### DIFF
--- a/src/components/Course/Content/HiddenContent/index.js
+++ b/src/components/Course/Content/HiddenContent/index.js
@@ -1,8 +1,9 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import "./styles.scss";
 
 function HiddenContent(props) {
   const [hidden, setHidden] = useState(true);
+  useEffect(() => setHidden(true), [props]);
 
   return (
     <div id="hiddenContent__container">


### PR DESCRIPTION
**Which issue does this refer to ?**
Fixes #121 

**Brief description of the changes done**
1. Used `useEffect` hook to setState to hidden.
2. `useEffect` triggered on each mount, and set the dependency array to empty `[ ]` so it only updates on initial mount

**People to loop in / review from**
@komalahire @tarun-dugar @pysaquib 