### PR TITLE
Fix/prepopulate forms

### DIFF
--- a/src/components/Class/index.js
+++ b/src/components/Class/index.js
@@ -284,6 +284,7 @@ function Class({ classToEdit }) {
         initialFieldsState={initialFormState}
       >
         {({ formFieldsState, setFormField, setFormFieldsState }) => {
+          console.log(formFieldsState);
           return (
             <>
               <label htmlFor="type">Select Class Type</label>
@@ -298,6 +299,9 @@ function Class({ classToEdit }) {
                     }}
                     value={formFieldsState[TYPE]}
                     id="type1"
+                    checked={
+                      formFieldsState.type === "doubt_class" ? "checked" : false
+                    }
                   />
                   Doubt Class
                 </label>
@@ -311,6 +315,9 @@ function Class({ classToEdit }) {
                     }}
                     value={formFieldsState[TYPE]}
                     id="type2"
+                    checked={
+                      formFieldsState.type === "workshop" ? "checked" : false
+                    }
                   />
                   Workshop
                 </label>
@@ -324,6 +331,9 @@ function Class({ classToEdit }) {
                     }}
                     value={formFieldsState[TYPE]}
                     id="type3"
+                    checked={
+                      formFieldsState.type === "cohort" ? "checked" : false
+                    }
                   />
                   Cohort
                 </label>
@@ -449,6 +459,7 @@ function Class({ classToEdit }) {
                     }}
                     value={formFieldsState[LANG]}
                     id="lang"
+                    checked={formFieldsState.lang === "en" ? "checked" : false}
                   />
                   English
                 </label>
@@ -462,6 +473,7 @@ function Class({ classToEdit }) {
                     }}
                     value={formFieldsState[LANG]}
                     id="lang"
+                    checked={formFieldsState.lang === "hi" ? "checked" : false}
                   />
                   Hindi
                 </label>
@@ -475,6 +487,7 @@ function Class({ classToEdit }) {
                     }}
                     value={formFieldsState[LANG]}
                     id="lang"
+                    checked={formFieldsState.lang === "te" ? "checked" : false}
                   />
                   Telugu
                 </label>
@@ -488,6 +501,7 @@ function Class({ classToEdit }) {
                     }}
                     value={formFieldsState[LANG]}
                     id="lang"
+                    checked={formFieldsState.lang === "ta" ? "checked" : false}
                   />
                   Tamil
                 </label>
@@ -621,6 +635,11 @@ function Class({ classToEdit }) {
                         value={formFieldsState[ON_DAYS]}
                         id="on_days"
                         disabled={isEditMode ? true : false}
+                        checked={
+                          formFieldsState[ON_DAYS].indexOf("MO") > -1
+                            ? "checked"
+                            : false
+                        }
                       />
                       MO
                     </label>
@@ -641,6 +660,11 @@ function Class({ classToEdit }) {
                         value={[...formFieldsState[ON_DAYS]]}
                         id="on_days"
                         disabled={isEditMode ? true : false}
+                        checked={
+                          formFieldsState[ON_DAYS].indexOf("TU") > -1
+                            ? "checked"
+                            : false
+                        }
                       />
                       TU
                     </label>
@@ -661,6 +685,11 @@ function Class({ classToEdit }) {
                         value={[...formFieldsState[ON_DAYS]]}
                         id="on_days"
                         disabled={isEditMode ? true : false}
+                        checked={
+                          formFieldsState[ON_DAYS].indexOf("WE") > -1
+                            ? "checked"
+                            : false
+                        }
                       />
                       WE
                     </label>
@@ -681,6 +710,11 @@ function Class({ classToEdit }) {
                         value={formFieldsState[ON_DAYS]}
                         id="on_days"
                         disabled={isEditMode ? true : false}
+                        checked={
+                          formFieldsState[ON_DAYS].indexOf("TH") > -1
+                            ? "checked"
+                            : false
+                        }
                       />
                       TH
                     </label>
@@ -701,6 +735,11 @@ function Class({ classToEdit }) {
                         value={formFieldsState[ON_DAYS]}
                         id="on_days"
                         disabled={isEditMode ? true : false}
+                        checked={
+                          formFieldsState[ON_DAYS].indexOf("FR") > -1
+                            ? "checked"
+                            : false
+                        }
                       />
                       FR
                     </label>
@@ -721,6 +760,11 @@ function Class({ classToEdit }) {
                         value={formFieldsState[ON_DAYS]}
                         id="on_days"
                         disabled={isEditMode ? true : false}
+                        checked={
+                          formFieldsState[ON_DAYS].indexOf("SA") > -1
+                            ? "checked"
+                            : false
+                        }
                       />
                       SA
                     </label>
@@ -741,6 +785,11 @@ function Class({ classToEdit }) {
                         value={formFieldsState[ON_DAYS]}
                         id="on_days"
                         disabled={isEditMode ? true : false}
+                        checked={
+                          formFieldsState[ON_DAYS].indexOf("SU") > -1
+                            ? "checked"
+                            : false
+                        }
                       />
                       SU
                     </label>

--- a/src/components/Class/index.js
+++ b/src/components/Class/index.js
@@ -47,12 +47,18 @@ function Class({ classToEdit }) {
     exercise_id,
     max_enrolment,
     frequency,
-    on_days,
-    occurrence,
-    until,
+    parent_class,
   } = classToEdit;
 
   const initialFormState = useMemo(() => {
+    let on_days_list = [];
+    let occurrence_data = "";
+    let until_data = "";
+    if (parent_class) {
+      if (parent_class.on_days) on_days_list = parent_class.on_days.split(",");
+      if (parent_class.occurrence) occurrence_data = parent_class.occurrence;
+      if (parent_class.until) until_data = parent_class.until;
+    }
     return {
       [TITLE]: title || "",
       [DESCRIPTION]: description || "",
@@ -73,9 +79,9 @@ function Class({ classToEdit }) {
       [EXERCISE_ID]: exercise_id || "",
       [MAX_ENROLMENT]: max_enrolment || "",
       [FREQUENCY]: frequency || "",
-      [ON_DAYS]: on_days || [],
-      [OCCURRENCE]: occurrence || "",
-      [UNTIL]: until || "",
+      [ON_DAYS]: on_days_list || [],
+      [OCCURRENCE]: occurrence_data || "",
+      [UNTIL]: until_data || "",
     };
   }, [classToEdit]);
 
@@ -284,7 +290,6 @@ function Class({ classToEdit }) {
         initialFieldsState={initialFormState}
       >
         {({ formFieldsState, setFormField, setFormFieldsState }) => {
-          console.log(formFieldsState);
           return (
             <>
               <label htmlFor="type">Select Class Type</label>
@@ -512,7 +517,7 @@ function Class({ classToEdit }) {
               <select
                 className="input-field"
                 value={pathwayId}
-                required
+                required={isEditMode ? false : true}
                 aria-required
                 onChange={(e) => {
                   setPathwayId(e.target.value);
@@ -538,7 +543,7 @@ function Class({ classToEdit }) {
                         </label>
                         <select
                           className="input-field"
-                          required
+                          required={isEditMode ? false : true}
                           aria-required
                           name={COURSE_ID}
                           value={formFieldsState[COURSE_ID]}


### PR DESCRIPTION
**Which issue does this refer to ?**
Classes fields were not pre populated on edit form

**Brief description of the changes done**
1. Sending cohort related fields from backend to set it in the form (parent_class is that key)
2. Mostly check fields were having issues, fixed.
3. Since we are not maintaining any state for pathways field neither in client nor in server, and it is a mandatory field in `create mode`, made it optional in `edit mode`
