### PR TITLE
Grouping child exercises with parent

### DIFF
--- a/src/components/Course/Content/ExerciseList/Exercise/index.js
+++ b/src/components/Course/Content/ExerciseList/Exercise/index.js
@@ -88,11 +88,11 @@ function Exercise(props) {
   };
 
   const containerClasses =
-    selected && !haveChildExercises ? "ng-exercise-selected" : "";
+    selected && !haveChildExercises ? " ng-exercise-selected" : "";
   return (
     <div
-      className={`ng-exercise  ${containerClasses} ${
-        showChildExercise && "ng-exercise-child"
+      className={`ng-exercise${containerClasses}${
+        (showChildExercise || "") && " ng-exercise-child"
       }`}
       key={index}
     >
@@ -112,7 +112,7 @@ function Exercise(props) {
             <ExerciseTitle
               isChildExercise={haveChildExercises}
               exercise={childExercise}
-              selected={subExerciseIndex === selectedExercise.subExerciseIndex}
+              selected={selected && subExerciseIndex === selectedExercise.subExerciseIndex}
               onClick={() => handleExerciseClick(index, subExerciseIndex)}
               key={subExerciseIndex}
             />

--- a/src/components/Course/Content/ExerciseList/Exercise/index.js
+++ b/src/components/Course/Content/ExerciseList/Exercise/index.js
@@ -47,7 +47,7 @@ const ExerciseTitle = (props) => {
 
   return (
     <div
-      className={`content ${isChildExercise && "child-exercise"}`}
+      className={`content${(isChildExercise || "") && " child-exercise"}`}
       onClick={props.onClick}
     >
       {isChildExercise ? (

--- a/src/pages/CourseContent/index.js
+++ b/src/pages/CourseContent/index.js
@@ -141,11 +141,9 @@ function CourseContent(props) {
 
     // exercises loaded
     if (firstExercise) {
-      if (exerciseIdFromParams) {
-        setSelectedExercise(
-          getSelectedFromId(data.exerciseList, exerciseIdFromParams)
-        );
-      }
+      setSelectedExercise(
+        getSelectedFromId(data.exerciseList, exerciseIdFromParams)
+      );
     }
   }, [data]);
 


### PR DESCRIPTION
**Which issue does this refer to ?**
#120 

**Brief description of the changes done**
1. Updated `mapCourseContent` to only return the Array of parent exercises and have Array of child exercises become value of `childExercises` property for each parent.  Non-parents have a `childExercise` property of `null`.
2. Factored out common logic from callbacks to `useEffect` defined in src/pages/CourseContent/index.js that call `setSelectedExercise` to select the exercise specified in the URL. 
3. Added `parentExercise` and `subExerciseIndex` properties to the input to `setSelectedExercise` for cases where a subexercise is being requested to be selected from these callbacks to match what's done in src/components/Course/Content/ExerciseList/.
4. Replaced ``${fullUrl}/exercise/${exerciseId}` with `fullUrl` for setting storage.  Before, you'd be saving paths with an extra `/exercise/id #` because of this.  The path would be adjusted to remove this duplication, but if you clicked back fast enough and then clicked on the exercise to continue, you'd get `undefined` at the end of the path.

**People to loop in / review from**
@pysaquib @komalahire : This could definitely use some testing in the context of the full app.  In particular, I'm not familiar enough with the code repository to know how changes such as the one described in 1 may impact other parts of the codebase.  Happy to make any requested changes.  Thanks!