### PR TITLE
fix: Login via Redirect token

### DIFF
--- a/src/components/User/redux/api.js
+++ b/src/components/User/redux/api.js
@@ -21,6 +21,21 @@ export const sendGoogleUserData = (userData, tokens) => {
   });
 };
 
+
+/**
+ * Sends id-token to Meraki back-end to get profile data of registered user.
+ */
+export const sendToken = (userData, tokens) => {
+  return axios({
+      method: METHODS.GET,
+      url: `${process.env.REACT_APP_MERAKI_URL}/users/me`,
+      headers: {
+        accept: "application/json",
+        Authorization: userData.token,
+      },
+    });
+}
+
 export const updateUser = (userData, tokens) => {
   return axios({
     url: `${process.env.REACT_APP_MERAKI_URL}/users/me`,

--- a/src/components/User/redux/saga.js
+++ b/src/components/User/redux/saga.js
@@ -14,6 +14,7 @@ function* handleUserData({ data }) {
       yield call(sendGoogleUserData, data) :
       yield call(sendToken, data);
   if (res.status === 200) {
+    res.data.token = res.data.token || data.token;
     const mappedUserData = { ...res.data, isAuthenticated: true };
     yield put(actions.onUserSigninResolved(mappedUserData));
   } else {

--- a/src/components/User/redux/saga.js
+++ b/src/components/User/redux/saga.js
@@ -1,15 +1,18 @@
 import { takeLatest, put, call } from "redux-saga/effects";
 
 import { types, actions } from "./action";
-import { sendGoogleUserData } from "./api";
+import { sendGoogleUserData, sendToken } from "./api";
 import { PATHS } from "../../../constant";
 
 /**
- * Handles sending google sign in user udata to back-end
+ * Handles sending google sign in user udata or token to back-end
+ *     depending on login method
  * @param {object} payload
  */
-function* handleGoogleUserData({ data }) {
-  const res = yield call(sendGoogleUserData, data);
+function* handleUserData({ data }) {
+  const res = data.idToken ?
+      yield call(sendGoogleUserData, data) :
+      yield call(sendToken, data);
   if (res.status === 200) {
     const mappedUserData = { ...res.data, isAuthenticated: true };
     yield put(actions.onUserSigninResolved(mappedUserData));
@@ -23,6 +26,6 @@ function* handleLogout() {
 }
 
 export default function* () {
-  yield takeLatest(types.ON_USER_SIGN_INTENT, handleGoogleUserData);
+  yield takeLatest(types.ON_USER_SIGN_INTENT, handleUserData);
   yield takeLatest(types.ON_LOGOUT_INTENT, handleLogout);
 }

--- a/src/components/common/RedirectComponent/index.js
+++ b/src/components/common/RedirectComponent/index.js
@@ -10,11 +10,14 @@ function RedirectComponent() {
   // const uri = `https://www.merakilearn.org/redirect?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZC[…]JKeaoO_2neSYUVf0fl1yjYlGt9YLNOeLr12Xs&redirectUrl=admission`;
 
   const token = getQueryVariable("token");
-  const redirect = getQueryVariable("redirectUrl");
+  // undefined => "", remove leading slashes in redirect
+  const redirect = (getQueryVariable("redirectUrl") || "").replace(/^\/+/g, "");
 
-  localStorage.setItem("Token", token);
+  if (token) {
+    localStorage.setItem("Token", token);
+  }
 
-  return <Redirect to={uri.includes("token") ? redirect : PATHS.LOGIN} />;
+  return <Redirect to={uri.includes("token") ? "/" + redirect : PATHS.LOGIN} />;
 }
 
 export default RedirectComponent;

--- a/src/routing/Routes/OnlyLoggedIn.js
+++ b/src/routing/Routes/OnlyLoggedIn.js
@@ -19,7 +19,7 @@ const OnlyLoggedIn = (passedProps) => {
   //   isAuthorized = userHasAccess(User.user, roles || [])
   // }
 
-  if(user && !user.isAuthenticated && token) {
+  if(token && (!user || !user.isAuthenticated)) {
     // Registered user attempting to log in by using redirect token; 
     //     let's send the token to our back-end to get profile data
     //     from /users/me

--- a/src/routing/Routes/OnlyLoggedIn.js
+++ b/src/routing/Routes/OnlyLoggedIn.js
@@ -3,6 +3,7 @@ import { useSelector, useDispatch } from "react-redux";
 import PropTypes from "prop-types";
 import { Route, Redirect } from "react-router-dom";
 import { actions as userActions } from "../../components/User/redux/action";
+import Loader from "../../components/common/Loader";
 
 // import { userHasAccess } from '../../services/auth'
 import { PATHS } from "../../constant";

--- a/src/routing/Routes/OnlyLoggedIn.js
+++ b/src/routing/Routes/OnlyLoggedIn.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { useDispatch } from "react-redux";
+import { useSelector, useDispatch } from "react-redux";
 import PropTypes from "prop-types";
 import { Route, Redirect } from "react-router-dom";
 import { actions as userActions } from "../../components/User/redux/action";
@@ -10,6 +10,7 @@ import { PATHS } from "../../constant";
 const OnlyLoggedIn = (passedProps) => {
   const { user = {}, component: Component, ...rest } = passedProps;
   const dispatch = useDispatch();
+  const { loading } = useSelector(({ User }) => User);
   const token = localStorage.getItem("Token");
 
   // let isAuthorized = false
@@ -18,6 +19,10 @@ const OnlyLoggedIn = (passedProps) => {
   // } else if (User && User.user) {
   //   isAuthorized = userHasAccess(User.user, roles || [])
   // }
+
+  if(loading) {
+    return <Loader />;
+  }
 
   if(token && (!user || !user.isAuthenticated)) {
     // Registered user attempting to log in by using redirect token; 

--- a/src/routing/Routes/OnlyLoggedIn.js
+++ b/src/routing/Routes/OnlyLoggedIn.js
@@ -21,15 +21,16 @@ const OnlyLoggedIn = (passedProps) => {
   //   isAuthorized = userHasAccess(User.user, roles || [])
   // }
 
-  if(loading) {
+  if (loading) {
     return <Loader />;
   }
 
-  if(token && (!user || !user.isAuthenticated)) {
+  if (token && (!user || !user.isAuthenticated)) {
     // Registered user attempting to log in by using redirect token; 
     //     let's send the token to our back-end to get profile data
     //     from /users/me
     dispatch(userActions.onUserSignin({token}));
+    localStorage.removeItem("Token");
   }
 
   return (

--- a/src/routing/Routes/OnlyLoggedIn.js
+++ b/src/routing/Routes/OnlyLoggedIn.js
@@ -1,12 +1,16 @@
 import React from "react";
+import { useDispatch } from "react-redux";
 import PropTypes from "prop-types";
 import { Route, Redirect } from "react-router-dom";
+import { actions as userActions } from "../../components/User/redux/action";
 
 // import { userHasAccess } from '../../services/auth'
 import { PATHS } from "../../constant";
 
 const OnlyLoggedIn = (passedProps) => {
   const { user = {}, component: Component, ...rest } = passedProps;
+  const dispatch = useDispatch();
+  const token = localStorage.getItem("Token");
 
   // let isAuthorized = false
   // if (!roles) {
@@ -14,6 +18,13 @@ const OnlyLoggedIn = (passedProps) => {
   // } else if (User && User.user) {
   //   isAuthorized = userHasAccess(User.user, roles || [])
   // }
+
+  if(!user.isAuthenticated && token) {
+    // Registered user attempting to log in by using redirect token; 
+    //     let's send the token to our back-end to get profile data
+    //     from /users/me
+    dispatch(userActions.onUserSignin({token}));
+  }
 
   return (
     <Route

--- a/src/routing/Routes/OnlyLoggedIn.js
+++ b/src/routing/Routes/OnlyLoggedIn.js
@@ -19,7 +19,7 @@ const OnlyLoggedIn = (passedProps) => {
   //   isAuthorized = userHasAccess(User.user, roles || [])
   // }
 
-  if(!user.isAuthenticated && token) {
+  if(user && !user.isAuthenticated && token) {
     // Registered user attempting to log in by using redirect token; 
     //     let's send the token to our back-end to get profile data
     //     from /users/me

--- a/src/routing/index.js
+++ b/src/routing/index.js
@@ -43,7 +43,7 @@ const Routing = () => {
         component={NavgurukulIntroduce}
       />
       <Route exact path={PATHS.REDIRECT} component={RedirectComponent} />
-      <Route exact path={PATHS.ADMISSION} component={Admission} />
+      <PrivateRoute exact path={PATHS.ADMISSION} component={Admission} />
 
       {/* Private routes */}
       {/* <PrivateRoute


### PR DESCRIPTION
**Which issue does this refer to ?**
Allows login of already registered user via token entered in query string of `/redirect`, used for logging into Admissions (https://github.com/navgurukul/bhanwari-devi/pull/233)

**Brief description of the changes done**
1. Added `sendToken` method to `User` redux api.js, which uses the user token to get the user's profile data via a GET request to [/users/me](https://github.com/navgurukul/sansaar/blob/main/lib/routes/users.js#L445).
2. Modified User redux saga.js to call either this `sendGoogleUserData` or `sendUserData` depending on whether data has `idToken` required for request to [/users/auth/google](https://github.com/navgurukul/sansaar/blob/main/lib/routes/users.js#L66).
3. Modified logic of OnlyLoggedIn.js to get `Token` from `localstorage` and if present and the User is not already authenticated, to dispatch an [`ON_USER_SIGN_INTENT`](https://github.com/navgurukul/bhanwari-devi/blob/59b1aebe6e33902857ef491062207f543467ba4c/src/components/User/redux/action.js#L10) action with this `token` data.  `localstorage` would have its `Token` key set to the value of the `token` parameter in the query string of a request made to `/redirect`.
4. Made Admissions route private for testing fix.

**(Currently a draft but creating pull request for testing purposes.)**

**People to loop in / review from**
@Poonam-Singh-Bagh 