### PR TITLE
fix/Enable class join button when allowed to enter

### DIFF
--- a/src/components/Class/ClassCard/index.js
+++ b/src/components/Class/ClassCard/index.js
@@ -211,8 +211,9 @@ function ClassCard({ item, editClass }) {
   const EnrolledAndTimer = () => {
     const timeLeftOptions = {
       precision: [3, 3, 3, 2, 2, 1],
-      cutoffNumArr: [0, 0, 0, 0, 10, 0],
-      cutoffTextArr: ["", "", "", "", "joinNow", ""],
+      cutoffNumArr: [0, 0, 0, 0, 10, 60],
+      cutoffTextArr: ["", "", "", "", "joinNow", "joinNow"],
+      expiredText: "joinNow",
     };
     const [Timer, setTimer] = useState(timeLeftFormat(item.start_time, timeLeftOptions));
     const ONE_MINUTE = 60000; //millisecs

--- a/src/components/Class/ClassCard/index.js
+++ b/src/components/Class/ClassCard/index.js
@@ -209,10 +209,15 @@ function ClassCard({ item, editClass }) {
 
   console.log("indicator", indicator);
   const EnrolledAndTimer = () => {
-    const [Timer, setTimer] = useState(timeLeftFormat(item.start_time));
+    const timeLeftOptions = {
+      precision: [3, 3, 3, 2, 2, 1],
+      cutoffNumArr: [0, 0, 0, 0, 10, 0],
+      cutoffTextArr: ["", "", "", "", "joinNow", ""],
+    };
+    const [Timer, setTimer] = useState(timeLeftFormat(item.start_time, timeLeftOptions));
     const ONE_MINUTE = 60000; //millisecs
     setInterval(() => {
-      setTimer(timeLeftFormat(item.start_time));
+      setTimer(timeLeftFormat(item.start_time, timeLeftOptions));
     }, ONE_MINUTE);
     return (
       <>


### PR DESCRIPTION
**Which issue does this refer to ?**
Currently, the student will not be able to click on the button to join a class as it will remain disabled.

**Brief description of the changes done**
The `EnrolledAndTimer` component relies on `Timer` being the message `"joinNow"` to become enabled, but without a supplied `options` argument as is the case now, `timeLeftFormat` will `return` the amount of time remaining up until the start time is reached.  

Setting the minutes position of the `cutoffNumArr` and `cutoffTextArr` properties of the options argument to `10` and `"joinNow"` respectively, as done in this PR, means that when all larger units (years, months, and days) are 0 and the minutes unit is from `1` to `10`, `"joinNow"` will be the returned message.  With this fix, <s>the user will still not be able to join the class when there's less than 1 minute until the starting time or the class is in progress.  This is to copy what's currently being done for the volunteer automation flow.</s> the user will now be able to enroll any time after 11 minutes before class start time.

**People to loop in / review from**
@Poonam-Singh-Bagh @komalahire @kartiks26 @anandpatel504  