### PR TITLE
Fix/Future or Past component timer overflow

### DIFF
--- a/.github/workflows/build_test_react.yml
+++ b/.github/workflows/build_test_react.yml
@@ -7,7 +7,7 @@ name: Build and Test React App
 on:
   # Triggers the workflow on push (to given branches) or pull request events
   push:
-    branches: ["main", "dev", "classBatch"]
+    branches: ["main", "dev"]
   pull_request:
     types: [opened, reopened]
 

--- a/src/components/common/FutureOrPast/FutureOrPast.test.js
+++ b/src/components/common/FutureOrPast/FutureOrPast.test.js
@@ -4,10 +4,12 @@ import FutureOrPast from "./";
 // jest.setSystemTime
 
 describe("FutureOrPast", () => {
+  const SECOND = 1000; // in milliseconds
   const MINUTE = 60; // in seconds
   const HOUR = 60 * MINUTE;
   const DAY = 24 * HOUR;
   const YEAR = 365 * DAY;
+  const MAX_DELAY = 2**31 - 1;
 
   const checkFutureOrPast = (testTimes) => {
     const { rerender, getByText } = render(<FutureOrPast />);
@@ -17,7 +19,9 @@ describe("FutureOrPast", () => {
         <FutureOrPast
           //startTime="2022-06-21T03:25:00.000+05:30"
           date={
-            new Date(new Date().setSeconds(new Date().getSeconds() + testTime))
+            new Date(
+              new Date().setMilliseconds(new Date().getMilliseconds() + testTime)
+            )
           }
           future={<div>future</div>}
           past={<div>past</div>}
@@ -32,23 +36,29 @@ describe("FutureOrPast", () => {
 
   it("Should show future element if given date is in the future", () => {
     checkFutureOrPast([
-      Math.floor(Math.random() * 60) + 5,
+      (Math.floor(Math.random() * 60) + 5) * SECOND,
       7 * HOUR,
       DAY + 3 * HOUR + 5 * MINUTE,
       2 * DAY + HOUR,
       7 * DAY,
       Math.floor(Math.random() * 59 + 1) * MINUTE,
+      MAX_DELAY,
+      MAX_DELAY + 1,
+      YEAR,
     ]);
   });
 
   it("Should show past element if given date is in the past", () => {
     checkFutureOrPast([
-      -(Math.floor(Math.random() * 60) + 5),
+      -(Math.floor(Math.random() * 60) + 5) * SECOND,
       -7 * HOUR,
       -(DAY + 3 * HOUR + 5 * MINUTE),
       -(2 * DAY + HOUR),
       -7 * DAY,
       -Math.floor(Math.random() * 59 + 1) * MINUTE,
+      -MAX_DELAY,
+      -(MAX_DELAY + 1),
+      -YEAR,
     ]);
   });
 });

--- a/src/components/common/FutureOrPast/FutureOrPast.test.js
+++ b/src/components/common/FutureOrPast/FutureOrPast.test.js
@@ -5,7 +5,7 @@ import FutureOrPast from "./";
 
 describe("FutureOrPast", () => {
   const SECOND = 1000; // in milliseconds
-  const MINUTE = 60; // in seconds
+  const MINUTE = 60 * SECOND;
   const HOUR = 60 * MINUTE;
   const DAY = 24 * HOUR;
   const YEAR = 365 * DAY;

--- a/src/components/common/FutureOrPast/index.js
+++ b/src/components/common/FutureOrPast/index.js
@@ -22,7 +22,7 @@ function FutureOrPast({ future = "", past = "", date = new Date() }) {
     if (isInFuture && msUntilDate <= 2**31 - 1) {
       const timer = setTimeout(() => {
         setIsInFuture(false);
-      }, msUntilDate);  
+      }, msUntilDate);
       return () => clearTimeout(timer); // cleans up on unmount
     }
   }, [date]);

--- a/src/components/common/FutureOrPast/index.js
+++ b/src/components/common/FutureOrPast/index.js
@@ -15,11 +15,14 @@ function FutureOrPast({ future = "", past = "", date = new Date() }) {
   const [isInFuture, setIsInFuture] = useState(!isBeforeNow(date));
 
   useEffect(() => {
+    const msUntilDate = millisecondsUntil(date);
     setIsInFuture(!isBeforeNow(date));
-    if (isInFuture) {
+    // Don't set timer if it's too far in future:
+    //     https://developer.mozilla.org/en-US/docs/Web/API/setTimeout#maximum_delay_value
+    if (isInFuture && msUntilDate <= 2**31 - 1) {
       const timer = setTimeout(() => {
         setIsInFuture(false);
-      }, millisecondsUntil(date));
+      }, msUntilDate);  
       return () => clearTimeout(timer); // cleans up on unmount
     }
   }, [date]);


### PR DESCRIPTION
**Which issue does this refer to ?**
* Don't set timer that changes the component to show from the future one to the past one when the date occurs, if it is too far in the future (at least 2<sup>31</sup> milliseconds) as it will incorrectly show the past one immediately (See https://developer.mozilla.org/en-US/docs/Web/API/setTimeout#maximum_delay_value)

**People to loop in / review from**
@kartiks26 