### PR TITLE
Fix/Add / after base URL environment variables

### DIFF
--- a/src/components/BatchClassComponents/Revision/RevisionClassEnroll.js
+++ b/src/components/BatchClassComponents/Revision/RevisionClassEnroll.js
@@ -30,7 +30,7 @@ function RevisionClassEnroll(props) {
   useEffect(() => {
     axios({
       method: METHODS.GET,
-      url: `${process.env.REACT_APP_MERAKI_URL}classes/${id}/revision`,
+      url: `${process.env.REACT_APP_MERAKI_URL}/classes/${id}/revision`,
       headers: {
         accept: "application/json",
         Authorization: user?.data?.token,

--- a/src/components/DropOutBatches/DropOutBatchesProfile.js
+++ b/src/components/DropOutBatches/DropOutBatchesProfile.js
@@ -79,7 +79,7 @@ function DropOutBatchesProfile() {
   useEffect(() => {
     axios({
       method: METHODS.GET,
-      url: `${process.env.REACT_APP_MERAKI_URL}users/EnrolledBatches`,
+      url: `${process.env.REACT_APP_MERAKI_URL}/users/EnrolledBatches`,
       headers: {
         accept: "application/json",
         Authorization: user.data.token,

--- a/src/components/NewUserDashbord/index.js
+++ b/src/components/NewUserDashbord/index.js
@@ -61,7 +61,7 @@ const NewUserDashbord = () => {
   useEffect(() => {
     axios({
       method: METHODS.GET,
-      url: `${process.env.REACT_APP_MERAKI_URL}progressTracking/learningTrackStatus`,
+      url: `${process.env.REACT_APP_MERAKI_URL}/progressTracking/learningTrackStatus`,
       headers: {
         "version-code": versionCode,
         accept: "application/json",

--- a/src/components/PathwayCourse/redux/api.js
+++ b/src/components/PathwayCourse/redux/api.js
@@ -29,7 +29,7 @@ export const getUpcomingBatches = (data) => {
   const { pathwayId, authToken } = data;
   return axios({
     method: METHODS.GET,
-    url: `${process.env.REACT_APP_MERAKI_URL}pathways/${pathwayId}/upcomingBatches`,
+    url: `${process.env.REACT_APP_MERAKI_URL}/pathways/${pathwayId}/upcomingBatches`,
     headers: {
       accept: "application/json",
       Authorization: authToken,
@@ -41,7 +41,7 @@ export const getupcomingEnrolledClasses = (data) => {
   const { pathwayId, authToken } = data;
   return axios({
     method: METHODS.GET,
-    url: `${process.env.REACT_APP_MERAKI_URL}pathways/${pathwayId}/upcomingEnrolledClasses`,
+    url: `${process.env.REACT_APP_MERAKI_URL}/pathways/${pathwayId}/upcomingEnrolledClasses`,
     headers: {
       accept: "application/json",
       Authorization: authToken,
@@ -53,7 +53,7 @@ export const getEnrolledBatches = (data) => {
   const { pathwayId, authToken } = data;
   return axios({
     method: METHODS.GET,
-    url: `${process.env.REACT_APP_MERAKI_URL}pathways/${pathwayId}/enrolledBatches`,
+    url: `${process.env.REACT_APP_MERAKI_URL}/pathways/${pathwayId}/enrolledBatches`,
     headers: {
       accept: "application/json",
       Authorization: authToken,

--- a/src/components/PathwayExercise/index.js
+++ b/src/components/PathwayExercise/index.js
@@ -178,7 +178,7 @@ function PathwayExercise() {
   useEffect(() => {
     axios({
       method: METHODS.GET,
-      url: `${process.env.REACT_APP_MERAKI_URL}progressTracking/learningTrackStatus`,
+      url: `${process.env.REACT_APP_MERAKI_URL}/progressTracking/learningTrackStatus`,
       headers: {
         "version-code": versionCode,
         accept: "application/json",
@@ -260,7 +260,7 @@ function PathwayExercise() {
       if (parseInt(params.exerciseId) >= progressTrackId) {
         axios({
           method: METHODS.POST,
-          url: `${process.env.REACT_APP_MERAKI_URL}progressTracking/learningTrackStatus`,
+          url: `${process.env.REACT_APP_MERAKI_URL}/progressTracking/learningTrackStatus`,
           headers: {
             "version-code": versionCode,
             accept: "application/json",
@@ -280,7 +280,7 @@ function PathwayExercise() {
 
         axios({
           method: METHODS.POST,
-          url: `${process.env.REACT_APP_MERAKI_URL}progressTracking/learningTrackStatus`,
+          url: `${process.env.REACT_APP_MERAKI_URL}/progressTracking/learningTrackStatus`,
           headers: {
             "version-code": versionCode,
             accept: "application/json",

--- a/src/components/ReturningUser/ReturningUserPage.js
+++ b/src/components/ReturningUser/ReturningUserPage.js
@@ -36,7 +36,7 @@ function ReturningUserPage() {
   useEffect(() => {
     axios({
       method: METHODS.GET,
-      url: `${process.env.REACT_APP_MERAKI_URL}progressTracking/learningTrackStatus`,
+      url: `${process.env.REACT_APP_MERAKI_URL}/progressTracking/learningTrackStatus`,
       headers: {
         "version-code": versionCode,
         accept: "application/json",

--- a/src/pages/Navgurukul/merakiAdmission/index.js
+++ b/src/pages/Navgurukul/merakiAdmission/index.js
@@ -49,7 +49,7 @@ function Admission(props) {
   const generateTestLink = async () => {
     try {
       const mobile = `0${userDetails.mobileNumber}`;
-      const dataURL = `${process.env.REACT_APP_CHANAKYA_BASE_URL}helpline/register_exotel_call`;
+      const dataURL = `${process.env.REACT_APP_CHANAKYA_BASE_URL}/helpline/register_exotel_call`;
       const response = await axios.get(dataURL, {
         params: {
           ngCallType: "getEnrolmentKey",
@@ -69,7 +69,7 @@ function Admission(props) {
         .map((key) => `${key}=${params[key]}`)
         .join("&");
 
-      const url = `${process.env.REACT_APP_TEST_URL}${enrolmentKey}?${queryString}`;
+      const url = `${process.env.REACT_APP_TEST_URL}/${enrolmentKey}?${queryString}`;
 
       window.open(url, "_blank");
       return response;
@@ -119,7 +119,7 @@ function Admission(props) {
         const response = data.data.data;
         const stage = response.pendingInterviewStage;
         const url =
-          `${process.env.REACT_APP_ADMISSIONS_URL}check_duplicate/` +
+          `${process.env.REACT_APP_ADMISSIONS_URL}/check_duplicate/` +
           new URLSearchParams({
             Name: `${firstName}${middleName}${lastName}`,
             Number: mobileNumber,
@@ -267,7 +267,7 @@ function Admission(props) {
                   />
                   <Button variant="contained" color="primary">
                     <ExternalLink
-                      href={`${process.env.REACT_APP_ADMISSIONS_URL}status/${mobile}`}
+                      href={`${process.env.REACT_APP_ADMISSIONS_URL}/status/${mobile}`}
                       style={{ color: "white", textDecoration: "none" }}
                     >
                       Check Result


### PR DESCRIPTION
**Which issue does this refer to ?**
https://github.com/navgurukul/bhanwari-devi/pull/431#discussion_r891339459 : 
> IMPORTANT: There are a number of places that do not contain a trailing / after ${process.env.REACT_APP_MERAKI_URL}. From what I can tell, this will refer to https://dev-api.merakilearn.org/ in the development environment, but https://api.merakilearn.org (without the trailing /) in production. So, this would refer to say https://api.merakilearn.orgpathways/1/upcomingBatches, causing bad requests and lots of problems after merging into main (You can see these requests if you open up the Developer console and check the Network tab before visiting https://pr-431.dkchei85ij0cu.amplifyapp.com/course-content/1/370/1).

**Brief description of the changes done**
* Performed a recursive search of all files in `src` folder repository for regex `{process.env.[^}]*}[^/]` and added `/` at end where appropriate.

**Action items**
Environment variables that should have their trailing slash removed, if present:
```
REACT_APP_MERAKI_URL
REACT_APP_ADMISSIONS_URL
REACT_APP_CHANAKYA_BASE_URL
```

**People to loop in / review from**
@kartiks26 @anandpatel504 