### PR TITLE
Perf/Determine load of upcoming batches w/selector

### DIFF
--- a/src/components/PathwayCourse/index.js
+++ b/src/components/PathwayCourse/index.js
@@ -86,7 +86,7 @@ function PathwayCourse() {
   const isActive = useMediaQuery("(max-width:" + breakpoints.values.sm + "px)");
   const params = useParams();
   const pathwayId = params.pathwayId;
-  const [loading, setLoading] = useState(true);
+  // const [loading, setLoading] = useState(true);
   // const [enrolledBatches, setEnrolledBatches] = useState(null);
   const data = useSelector((state) => {
     return state;
@@ -106,7 +106,15 @@ function PathwayCourse() {
       return null;
     }
   });
+  
+  const loading = useSelector((state) => {
+    return (state?.Pathways?.enrolledBatches?.loading || 
+      state?.Pathways?.upcomingBatchesData?.loading) &&
+      !(upcomingBatchesData?.length > 0) && !(enrolledBatches?.length > 0)
+  });
+  
   console.log("upcomingBatchesData", upcomingBatchesData);
+  /*
   useEffect(() => {
     setTimeout(() => {
       setLoading(false);
@@ -121,6 +129,7 @@ function PathwayCourse() {
       setLoading(false);
     }
   }, [upcomingBatchesData, enrolledBatches, userEnrolledClasses]);
+  */
   const history = useHistory();
 
   useEffect(() => {
@@ -128,7 +137,7 @@ function PathwayCourse() {
   }, [dispatch, pathwayId]);
 
   useEffect(() => {
-    setLoading(true);
+    // setLoading(true);
     if (user?.data?.token) {
       dispatch(
         enrolledBatchesActions.getEnrolledBatches({

--- a/src/components/PathwayCourse/index.js
+++ b/src/components/PathwayCourse/index.js
@@ -108,9 +108,11 @@ function PathwayCourse() {
   });
   
   const loading = useSelector((state) => {
-    return (state?.Pathways?.enrolledBatches?.loading || 
-      state?.Pathways?.upcomingBatchesData?.loading) &&
-      !(upcomingBatchesData?.length > 0) && !(enrolledBatches?.length > 0)
+    const upcomingBatchesState = state?.Pathways?.upcomingBatches;
+    const enrolledBatchesState = state?.Pathways?.enrolledBatches;
+    return (!upcomingBatchesState || !enrolledBatchesState ||
+      upcomingBatchesState.loading || enrolledBatchesState.loading) &&
+      !(upcomingBatchesData?.length > 0) && !(enrolledBatches?.length > 0);
   });
   
   console.log("upcomingBatchesData", upcomingBatchesData);


### PR DESCRIPTION
* Use instead of deterministic 10 s load when there are no batches to display for pathway

**Which issue does this refer to ?**
When there were no batches to display for a given pathway, it would wait with a loading display for over 10s.

**Brief description of the changes done**
Removed `setTimeout` in favor of check that there were pending requests for upcoming or enrolled batches and there were no upcoming or enrolled batches to display.  With this change, the user is alerted that no such batches are available as soon as the responses (error or not) are received, which should hopefully be substantially less than 10 seconds.

**People to loop in / review from**
@kartiks26 