### PR TITLE
Perf-fix/Simulate getting upcoming batch classes from API to get classes starting from last week

### DIFF
--- a/src/components/BatchClassComponents/CheckMoreBatches.js
+++ b/src/components/BatchClassComponents/CheckMoreBatches.js
@@ -56,7 +56,7 @@ export default function CheckMoreBatches(props) {
                   alt="Students Img"
                 />
                 {format(item.start_time, "dd MMM yy")} -{" "}
-                {format(item.end_time, "dd MMM yy")}
+                {format(item.end_batch_time, "dd MMM yy")}
               </Typography>
               <Button
                 fullWidth
@@ -65,7 +65,7 @@ export default function CheckMoreBatches(props) {
                   setAlertData({
                     title: item.title,
                     start_time: item.start_time,
-                    end_time: item.end_time,
+                    end_time: item.end_batch_time,
                     id: item.id,
                   });
                 }}
@@ -80,7 +80,7 @@ export default function CheckMoreBatches(props) {
             close={close}
             title={AlertData?.title}
             start_time={AlertData?.start_time}
-            end_time={AlertData?.end_time}
+            end_time={AlertData?.end_batch_time}
             id={AlertData?.id}
             registerAll={true}
             type="batch"

--- a/src/components/BatchClassComponents/PathwayCourseBatchEnroll1.js
+++ b/src/components/BatchClassComponents/PathwayCourseBatchEnroll1.js
@@ -58,7 +58,7 @@ const PathwayCourseBatchEnroll1 = (props) => {
                   alt="Students Img"
                 />
                 From {format(BatchData?.start_time, "dd MMM yy")} -{" "}
-                {format(BatchData?.end_time, "dd MMM yy")}
+                {format(BatchData?.end_batch_time, "dd MMM yy")}
               </Typography>
               <Typography
                 variant="body1"
@@ -80,7 +80,7 @@ const PathwayCourseBatchEnroll1 = (props) => {
                 close={close}
                 title={BatchData?.title}
                 start_time={BatchData?.start_time}
-                end_time={BatchData?.end_time}
+                end_time={BatchData?.end_batch_time}
                 id={BatchData?.id}
                 registerAll={true}
                 type="batch"

--- a/src/components/BatchClassComponents/PathwayCourseBatchEnroll2.js
+++ b/src/components/BatchClassComponents/PathwayCourseBatchEnroll2.js
@@ -48,7 +48,7 @@ const PathwayCourseBatchEnroll2 = (props) => {
               alt="Students Img"
             />
             {format(upcomingBatchesData[0]?.start_time, "dd MMM yy")} -{" "}
-            {format(upcomingBatchesData[0]?.end_time, "dd MMM yy")}
+            {format(upcomingBatchesData[0]?.end_batch_time, "dd MMM yy")}
           </Typography>
           <Typography
             variant="body1"
@@ -70,7 +70,7 @@ const PathwayCourseBatchEnroll2 = (props) => {
               close={close}
               title={upcomingBatchesData[0]?.title}
               start_time={upcomingBatchesData[0]?.start_time}
-              end_time={upcomingBatchesData[0]?.end_time}
+              end_time={upcomingBatchesData[0]?.end_batch_time}
               id={upcomingBatchesData[0]?.id}
               registerAll={true}
               type="batch"

--- a/src/components/PathwayCourse/redux/api.js
+++ b/src/components/PathwayCourse/redux/api.js
@@ -105,7 +105,8 @@ export const getUpcomingBatches = (data) => {
     upcomingBatchClasses.map(c => classesStartingFromLastWeekRev.find(d => c.recurring_id === d.recurring_id))
       .forEach((c, index) => upcomingBatchClasses[index].end_batch_time = c.end_time);
     
-    return upcomingBatchClasses;
+    response.data = upcomingBatchClasses;
+    return response;
   });  
 };
 

--- a/src/components/PathwayCourse/redux/api.js
+++ b/src/components/PathwayCourse/redux/api.js
@@ -96,7 +96,7 @@ export const getUpcomingBatches = (data) => {
     classesStartingFromLastWeek.forEach(c => {
       // map old to new pathway for Python (fix, very hacky)
       const cPathwayId = c.pathway_v2 || ({"39": 1})[c.pathway_v1] || c.pathway_v1 || c.pathway_id;
-      if (c.recurring_id && !recurringIds.has(c.recurring_id) && cPathwayId === pathwayId) {
+      if (c.recurring_id && !recurringIds.has(c.recurring_id) && cPathwayId == pathwayId) {
         recurringIds.add(c.recurring_id);
         new Date(c.start_time) < new Date() && upcomingBatchClasses.push(c); 
       }

--- a/src/components/PathwayCourse/redux/api.js
+++ b/src/components/PathwayCourse/redux/api.js
@@ -93,8 +93,10 @@ export const getUpcomingBatches = (data) => {
     const recurringIds = new Set();
     const upcomingBatchClasses = [];
     
-    classesStartingFromLastWeek.forEach(c => { 
-      if (c.recurring_id && !recurringIds.has(c.recurring_id) && c.parent_class?.on_days) {
+    classesStartingFromLastWeek.forEach(c => {
+      // map old to new pathway for Python (fix, very hacky)
+      const cPathwayId = c.pathway_v2 || ({"39": 1})[c.pathway_v1] || c.pathway_v1 || c.pathway_id;
+      if (c.recurring_id && !recurringIds.has(c.recurring_id) && cPathwayId === pathwayId) {
         recurringIds.add(c.recurring_id);
         new Date(c.start_time) < new Date() && upcomingBatchClasses.push(c); 
       }

--- a/src/components/PathwayCourse/redux/api.js
+++ b/src/components/PathwayCourse/redux/api.js
@@ -98,7 +98,7 @@ export const getUpcomingBatches = (data) => {
       const cPathwayId = c.pathway_v2 || ({"39": 1})[c.pathway_v1] || c.pathway_v1 || c.pathway_id;
       if (c.recurring_id && !recurringIds.has(c.recurring_id) && cPathwayId == pathwayId) {
         recurringIds.add(c.recurring_id);
-        new Date(c.start_time) < new Date() && upcomingBatchClasses.push(c); 
+        new Date(c.start_time) > new Date() && upcomingBatchClasses.push(c); 
       }
     });
     

--- a/src/components/PathwayCourse/redux/api.js
+++ b/src/components/PathwayCourse/redux/api.js
@@ -75,7 +75,7 @@ export const getUpcomingBatches = (data) => {
   */
   return axios({
     method: METHODS.GET,
-    url: `${process.env.REACT_APP_MERAKI_URL}/classes/all?startDate='+new Date(new Date().valueOf() - 7*24*60*60*1000).valueOf()`,
+    url: `${process.env.REACT_APP_MERAKI_URL}/classes/all?startDate=${new Date(new Date().valueOf() - 7*24*60*60*1000).valueOf()}`,
     headers: {
       accept: "application/json",
       Authorization: authToken,

--- a/src/components/PathwayExercise/ExerciseContent/index.js
+++ b/src/components/PathwayExercise/ExerciseContent/index.js
@@ -374,7 +374,7 @@ function ExerciseContent({ exerciseId, lang }) {
                     id={courseData.id}
                     facilitator={courseData.facilitator.name}
                     start_time={courseData.start_time}
-                    end_time={courseData.end_time}
+                    end_time={courseData.end_batch_time}
                     is_enrolled={courseData.is_enrolled}
                     meet_link={courseData.meet_link}
                   />


### PR DESCRIPTION
**Which issue does this refer to ?**
Decreases time to get upcoming batch classes, correctly shows last date for batches by using the ending time of the last class with that recurring id.

**Brief description of the changes done**
A brief step by step changes made. Example :
1. Simulate `getUpcomingBatches` API call by instead making API call to get classes starting from last week.  For each recurring id belonging to a class starting in the future, include the first such class.  I.e., The recurring id for that class did not appear in the past week. 
2. For each such upcoming batch class, attach `end_batch_time` property by using the ending time of the last class with the same recurring id.
3. Use `end_batch_time` instead of `end_time`.

**People to loop in / review from**
Use `@` key to tag people to review from