### PR TITLE
Update to add volunteer role without manually logging out and logging back in again

### DIFF
--- a/src/components/User/redux/action.js
+++ b/src/components/User/redux/action.js
@@ -2,6 +2,10 @@ export const types = {
   ON_USER_SIGN_INTENT: "ON_USER_SIGN_INTENT",
   ON_USER_SIGN_INTENT_RESOLVED: "ON_USER_SIGN_INTENT_RESOLVED",
   ON_USER_SIGN_INTENT_REJECTED: "ON_USER_SIGN_INTENT_REJECTED",
+  ON_USER_UPDATE: "ON_USER_UPDATE",
+  ON_USER_REFRESH_DATA_INTENT: "ON_USER_REFRESH_DATA_INTENT",
+  ON_USER_REFRESH_DATA_SUCCESS: "ON_USER_REFRESH_DATA_RESOLVED",
+  ON_USER_REFRESH_DATA_FAILURE: "ON_USER_REFRESH_DATA_FAILURE",
 
   ON_LOGOUT_INTENT: "ON_LOGOUT_INTENT",
 };
@@ -28,6 +32,24 @@ export const actions = {
   onUserSigninRejected(error) {
     return {
       type: types.ON_USER_SIGN_INTENT_REJECTED,
+      error,
+    };
+  },
+  onUserRefreshDataIntent(data) {
+    return {
+      type: types.ON_USER_REFRESH_DATA_INTENT,
+      data,
+    };
+  },
+  onUserRefreshDataSuccess(data) {
+    return {
+      type: types.ON_USER_REFRESH_DATA_SUCCESS,
+      data,
+    };
+  },
+  onUserRefreshDataFailure(error) {
+    return {
+      type: types.ON_USER_REFRESH_DATA_FAILURE,
       error,
     };
   },

--- a/src/components/User/redux/reducer.js
+++ b/src/components/User/redux/reducer.js
@@ -31,6 +31,29 @@ export default (state = initialState, action) => {
         data: null,
       };
 
+    case types.ON_USER_REFRESH_DATA_INTENT:
+      return {
+        ...state,
+        loading: true,
+        error: false,
+        data: null,
+      };
+    case types.ON_USER_REFRESH_DATA_SUCCESS:
+      return {
+        ...state,
+        loading: false,
+        error: false,
+        data: action.data,
+      };
+
+    case types.ON_USER_REFRESH_DATA_FAILURE:
+      return {
+        ...state,
+        loading: false,
+        error: action.error,
+        data: null,
+      };
+
     default:
       return state;
   }

--- a/src/components/User/redux/reducer.js
+++ b/src/components/User/redux/reducer.js
@@ -36,7 +36,7 @@ export default (state = initialState, action) => {
         ...state,
         loading: true,
         error: false,
-        data: null,
+        // data: null,
       };
     case types.ON_USER_REFRESH_DATA_SUCCESS:
       return {

--- a/src/components/User/redux/saga.js
+++ b/src/components/User/redux/saga.js
@@ -38,6 +38,6 @@ function* handleLogout() {
 
 export default function* () {
   yield takeLatest(types.ON_USER_SIGN_INTENT, handleUserData);
-  yield takeLatest(types.ON_USER_REFRESH_DATA_SUCCESS, refreshUserData);
+  yield takeLatest(types.ON_USER_REFRESH_DATA_INTENT, refreshUserData);
   yield takeLatest(types.ON_LOGOUT_INTENT, handleLogout);
 }

--- a/src/components/User/redux/saga.js
+++ b/src/components/User/redux/saga.js
@@ -25,6 +25,7 @@ function* handleUserData({ data }) {
 function* refreshUserData({ data }) {
   const res = yield call(sendToken, data);
   if (res.status === 200) {
+    res.data.token = data.token;
     const mappedUserData = { ...res.data, isAuthenticated: true };
     yield put(actions.onUserRefreshDataSuccess(mappedUserData));
   } else {

--- a/src/components/User/redux/saga.js
+++ b/src/components/User/redux/saga.js
@@ -22,11 +22,22 @@ function* handleUserData({ data }) {
   }
 }
 
+function* refreshUserData({ data }) {
+  const res = yield call(sendToken, data);
+  if (res.status === 200) {
+    const mappedUserData = { ...res.data, isAuthenticated: true };
+    yield put(actions.onUserRefreshDataSuccess(mappedUserData));
+  } else {
+    yield put(actions.onUserRefreshDataFailure(res));
+  }
+}
+
 function* handleLogout() {
   yield (window.location.pathname = PATHS.LOGIN);
 }
 
 export default function* () {
   yield takeLatest(types.ON_USER_SIGN_INTENT, handleUserData);
+  yield takeLatest(types.ON_USER_REFRESH_DATA_SUCCESS, refreshUserData);
   yield takeLatest(types.ON_LOGOUT_INTENT, handleLogout);
 }

--- a/src/components/VolunteerAutomation/Stepper.js
+++ b/src/components/VolunteerAutomation/Stepper.js
@@ -19,6 +19,7 @@ import IntroVideo from "./IntroVideo";
 import axios from "axios";
 import { useSelector } from "react-redux";
 import { METHODS } from "../../services/api";
+import { actions } from "../User/redux/action";
 
 import "./styles.scss";
 import { getObjectState, saveObjectState } from "../../common/storage";
@@ -29,6 +30,7 @@ function HorizontalLinearStepper() {
     completed: [],
   };
   const user = useSelector(({ User }) => User);
+  const dispatch = React.useDispatch();
   const [activeStep, setActiveStep] = React.useState(currentState.step || 0);
   const [skipped, setSkipped] = React.useState(new Set());
   const [completed, setCompleted] = React.useState(currentState.completed);
@@ -157,6 +159,7 @@ function HorizontalLinearStepper() {
       (res) => {
         localStorage.setItem("isNewVolunteer", true);
         history.push(PATHS.CLASS);
+        dispatch(actions.onUserRefreshDataIntent({token: user.data.token}));
       },
       (error) => {
         console.log(error);

--- a/src/components/VolunteerAutomation/Stepper.js
+++ b/src/components/VolunteerAutomation/Stepper.js
@@ -30,7 +30,7 @@ function HorizontalLinearStepper() {
     completed: [],
   };
   const user = useSelector(({ User }) => User);
-  const roles = user?.data?.user.roles; // TODO: Use selector for this
+  const roles = user?.data?.user.rolesList; // TODO: Use selector for this
   const dispatch = useDispatch();
   const [activeStep, setActiveStep] = React.useState(currentState.step || 0);
   const [skipped, setSkipped] = React.useState(new Set());

--- a/src/components/VolunteerAutomation/Stepper.js
+++ b/src/components/VolunteerAutomation/Stepper.js
@@ -158,15 +158,30 @@ function HorizontalLinearStepper() {
         accept: "application/json",
         Authorization: user.data.token,
       },
-      data: { // TODO: This data isn't saved in the back-end
+      data: {
         contact: contact,
         pathway_id: pathwayId,
       },
     }).then(
       (res) => {
-        localStorage.setItem("isNewVolunteer", true);
-        // history.push(PATHS.CLASS);
-        dispatch(actions.onUserRefreshDataIntent({token: user.data.token}));
+        return axios({
+          url: `${process.env.REACT_APP_MERAKI_URL}/users/volunteerRole`,
+          method: METHODS.POST,
+          headers: {
+            accept: "application/json",
+            Authorization: user.data.token,
+          },
+        }).then(
+          (res) => {
+            console.log("res", res);
+            localStorage.setItem("isNewVolunteer", true);
+            // history.push(PATHS.CLASS);
+            dispatch(actions.onUserRefreshDataIntent({token: user.data.token}));
+          },
+          (error) => {
+            console.log(error);
+          }
+        );
       },
       (error) => {
         console.log(error);

--- a/src/components/VolunteerAutomation/Stepper.js
+++ b/src/components/VolunteerAutomation/Stepper.js
@@ -17,7 +17,7 @@ import CodeOfConduct from "./CodeOfConduct";
 import VerifyPhoneNo from "./VerifyPhoneNo";
 import IntroVideo from "./IntroVideo";
 import axios from "axios";
-import { useSelector } from "react-redux";
+import { useSelector, useDispatch } from "react-redux";
 import { METHODS } from "../../services/api";
 import { actions } from "../User/redux/action";
 
@@ -30,7 +30,7 @@ function HorizontalLinearStepper() {
     completed: [],
   };
   const user = useSelector(({ User }) => User);
-  const dispatch = React.useDispatch();
+  const dispatch = useDispatch();
   const [activeStep, setActiveStep] = React.useState(currentState.step || 0);
   const [skipped, setSkipped] = React.useState(new Set());
   const [completed, setCompleted] = React.useState(currentState.completed);

--- a/src/components/VolunteerAutomation/Stepper.js
+++ b/src/components/VolunteerAutomation/Stepper.js
@@ -30,6 +30,7 @@ function HorizontalLinearStepper() {
     completed: [],
   };
   const user = useSelector(({ User }) => User);
+  const roles = user.data?.user.roles; // TODO: Use selector for this
   const dispatch = useDispatch();
   const [activeStep, setActiveStep] = React.useState(currentState.step || 0);
   const [skipped, setSkipped] = React.useState(new Set());
@@ -45,6 +46,12 @@ function HorizontalLinearStepper() {
     currentState[key] = value;
     saveObjectState("volunteer_automation", "state", currentState);
   };
+  
+  React.useEffect(() => {
+    if (roles.includes("volunteer")) {
+      history.push(PATHS.CLASS);
+    }
+  }, [roles]);
 
   const setActiveStepCompleted = () => {
     const newCompleted = completed.slice();
@@ -158,7 +165,7 @@ function HorizontalLinearStepper() {
     }).then(
       (res) => {
         localStorage.setItem("isNewVolunteer", true);
-        history.push(PATHS.CLASS);
+        // history.push(PATHS.CLASS);
         dispatch(actions.onUserRefreshDataIntent({token: user.data.token}));
       },
       (error) => {

--- a/src/components/VolunteerAutomation/Stepper.js
+++ b/src/components/VolunteerAutomation/Stepper.js
@@ -30,7 +30,7 @@ function HorizontalLinearStepper() {
     completed: [],
   };
   const user = useSelector(({ User }) => User);
-  const roles = user.data?.user.roles; // TODO: Use selector for this
+  const roles = user?.data?.user.roles; // TODO: Use selector for this
   const dispatch = useDispatch();
   const [activeStep, setActiveStep] = React.useState(currentState.step || 0);
   const [skipped, setSkipped] = React.useState(new Set());
@@ -48,7 +48,7 @@ function HorizontalLinearStepper() {
   };
   
   React.useEffect(() => {
-    if (roles.includes("volunteer")) {
+    if (roles?.includes("volunteer")) {
       history.push(PATHS.CLASS);
     }
   }, [roles]);
@@ -158,7 +158,7 @@ function HorizontalLinearStepper() {
         accept: "application/json",
         Authorization: user.data.token,
       },
-      data: {
+      data: { // TODO: This data isn't saved in the back-end
         contact: contact,
         pathway_id: pathwayId,
       },

--- a/src/components/VolunteerAutomation/index.js
+++ b/src/components/VolunteerAutomation/index.js
@@ -23,29 +23,14 @@ function VolunteerAutomation() {
   let history = useHistory();
 
   const pathname = window.location.pathname;
-  const rolesList = user && user.data && user.data.user.rolesList;
+  const rolesList = user?.data?.user.rolesList; // TODO: Use selector
 
   const handleClick = () => {
-    if (user && user.data && user.data.token) {
+    if (rolesList) {
       if (rolesList.includes("volunteer")) {
         history.push(PATHS.CLASS);
       } else {
-        return axios({
-          url: `${process.env.REACT_APP_MERAKI_URL}/users/volunteerRole`,
-          method: METHODS.POST,
-          headers: {
-            accept: "application/json",
-            Authorization: user.data.token,
-          },
-        }).then(
-          (res) => {
-            console.log("res", res);
-            history.push(PATHS.VOLUNTEER_FORM);
-          },
-          (error) => {
-            console.log(error);
-          }
-        );
+        history.push(PATHS.VOLUNTEER_FORM);
       }
     } else {
       history.push(PATHS.LOGIN, pathname);

--- a/src/services/storage.js
+++ b/src/services/storage.js
@@ -16,7 +16,10 @@ export function getUserInitialState() {
 }
 
 export const userStateMiddleware = (store) => (next) => (action) => {
-  if (action.type === types.ON_USER_SIGN_INTENT_RESOLVED) {
+  if (
+    action.type === types.ON_USER_SIGN_INTENT_RESOLVED ||
+    action.type === types.ON_USER_REFRESH_DATA_SUCCESS
+  ) {
     let result = next(action);
     const authState = store.getState().User;
     localStorage.setItem(AUTH_KEY, JSON.stringify(authState));


### PR DESCRIPTION
**Which issue does this refer to ?**
PR #560 

**Brief description of the changes done**
1. Added Redux for refreshing user data by making request to `users/me`.
2.  Dispatched the action to refresh the data, which should include the additional volunteer role after the user completes the volunteer flow.  This will allow the user to see the volunteer role in the header switch view without logging out and logging back in again.
3. Removed API request to add volunteer role in the click handler for the button to start the volunteer flow process for a couple of reasons:
a. If the user clicks to start the volunteer form and then logs out and logs back in, they will be redirected to class without being able to fill out the form.
b. Submitting multiple requests to this API endpoint `/users/volunteerRole` results in a `422 Error ({"error":true,"message":"Unique Key Violation","detail":"Key (user_id, role)=(id #, volunteer) already exists.","type":"UniqueViolationError","code":422})` (may be good to fix this on the back-end)

**People to loop in / review from**
@kartiks26 