### PR TITLE
solved

### DIFF
--- a/src/components/BatchClassComponents/styles.js
+++ b/src/components/BatchClassComponents/styles.js
@@ -120,6 +120,7 @@ const useStyles = makeStyles((theme) => ({
   },
   UnAvailableRevisionClass: {
     padding: "8px",
+    marginBottom: "35px",
   },
 }));
 


### PR DESCRIPTION
**ISSUE : No Revision Class Card was getting overlapped with bottom navigation in mobile view**

**Changes :**
Changed the css to make it scrollable not sticky.
Now it is visible with scroll.
