### PR TITLE
Fix/switch view drop down on hover on non-touch screens only

### DIFF
--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -15,6 +15,13 @@ const getIsMobile = () => {
   return check;
 };
 
+const isTouchScreen = () => {
+  // https://stackoverflow.com/a/4819886
+  return (('ontouchstart' in window) ||
+    (navigator.maxTouchPoints > 0) ||
+    (navigator.msMaxTouchPoints > 0));
+};
+
 const getQueryVariable = (queryVars) => {
   var query = window.location.search.substring(1);
   var vars = query.split("&");
@@ -28,4 +35,4 @@ const getQueryVariable = (queryVars) => {
 
 const hasOneFrom = (arr1, arr2) => arr2.some((item) => arr1.includes(item));
 
-module.exports = { getIsMobile, getQueryVariable, hasOneFrom };
+module.exports = { getIsMobile, getQueryVariable, hasOneFrom, isTouchScreen };

--- a/src/components/Header/ChangeRolesView/index.js
+++ b/src/components/Header/ChangeRolesView/index.js
@@ -17,6 +17,7 @@ import {
   STUDENT_ROLE_KEY as STUDENT,
   VOLUNTEER_ROLE_KEY as VOLUNTEER,
 } from "../constant";
+import { isTouchScreen } from "../../../common/utils"; 
 
 /*
 const rolesLandingPages = {
@@ -114,10 +115,9 @@ function ChangeRolesView({ setRole, roles, leftDrawer }) {
       {roles.length > 2 ? (
         <>
           <MenuItem
-            onMouseEnter={() => {
-              const mobile = window.innerWidth < 768;
-              if (!mobile) {
-                handleOpenSwitchView();
+            onMouseEnter={(e) => {
+              if (!isTouchScreen()) {
+                handleOpenSwitchView(e);
               }
             }}
             onClick={handleOpenSwitchView}


### PR DESCRIPTION
**Which issue does this refer to ?**
After PR https://github.com/navgurukul/bhanwari-devi/pull/645, the roles list dropdown would not appear on hover on browsers with widths of at least 768 pixels because `handleOpenSwitchView` was called without passing the `event` input, resulting in an error. Additionally, there can be touch screens with widths of at least 768 pixels where we'd want to disable the hover effect.

**Brief description of the changes done**
1. Added `isTouchScreen` function to detect whether a user is on a device with a touch screen where we wouldn't want the hover effect. 
2. Fixed the check for `onMouseEnter` so we would only call open the switch view for non-touch devices and added an input to the handler that could then be passed to `handleOpenSwitchView`.

**People to loop in / review from**
@kartiks26   