### PR TITLE
Fix/CreateClass modal crash

### DIFF
--- a/src/pages/CreateClass/index.js
+++ b/src/pages/CreateClass/index.js
@@ -119,7 +119,7 @@ function ToggleClassFormModal() {
       calledOnce.current = true;
     }
     if (calledOnce.current) {
-      return axios({
+      axios({
         method: METHODS.PUT,
         url: `${process.env.REACT_APP_MERAKI_URL}/users/calendar/tokens`,
 


### PR DESCRIPTION
**Which issue does this refer to ?**
A `Promise` was being returned from the input to `useEffect` which caused the crash. This is because if something is `return`ed, it will be called as a function when the component is unmounted, but a `Promise` cannot be called. The purpose of returning a function is for cleanup (https://reactjs.org/docs/hooks-effect.html#example-using-hooks-1).

**Brief description of the changes done**
1. Removed the `return` as we weren't doing cleanup.

**People to loop in / review from**
@Poonam-Singh-Bagh 