### PR TITLE
Fix/selected role for multiple accounts

### DIFF
--- a/src/components/Header/AuthenticatedHeaderOption.js
+++ b/src/components/Header/AuthenticatedHeaderOption.js
@@ -35,14 +35,12 @@ import PartnerHeader from "./PartnerHeader";
 import RoleSpecificHeader from "./RoleSpecificHeader";
 import SearchHeader from "./SearchHeader";
 import ChangeRolesView from "./ChangeRolesView";
-import { selectRolesData } from "../User/redux/selectors";
+import { selectRolesData, selectUserId } from "../User/redux/selectors";
 
 const savedRolesToKeysMap = Object.keys(ROLES).reduce((roleKeyMap, roleKey) => {
   roleKeyMap[ROLES[roleKey].savedValue] = roleKey;
   return roleKeyMap;
 }, {});
-
-const SELECTED_ROLE_KEY = "selectedRole";
 
 const rolesLandingPages = {
   [STUDENT]: PATHS.NEW_USER_DASHBOARD,
@@ -58,6 +56,7 @@ function AuthenticatedHeaderOption({
 }) {
   //const [RoleSpecificHeader, setRoleSpecificHeader] = React.useState(null);
   const roles = useSelector(selectRolesData);
+  const uid = useSelector(selectUserId);
   // const history = useHistory();
   // const location = useLocation();
 
@@ -124,7 +123,7 @@ function AuthenticatedHeaderOption({
           {...{ role, isUniqueRole, leftDrawer, toggleDrawer }}
         />
         <ChangeRolesView
-          {...{ setRole, roles: rolesWithLandingPages, leftDrawer }}
+          {...{ setRole, roles: rolesWithLandingPages, uid, leftDrawer }}
         />
       </Box>
       {!leftDrawer && <UserMenu />}

--- a/src/components/Header/ChangeRolesView/index.js
+++ b/src/components/Header/ChangeRolesView/index.js
@@ -28,7 +28,8 @@ const rolesLandingPages = {
 };
 */
 
-const SELECTED_ROLE_KEY = "selectedRole";
+// const SELECTED_ROLE_KEY = "selectedRole";
+const ID_TO_SELECTED_ROLE_MAP_KEY = "idToSelectedRoleMap";
 
 function ChangeRole({
   isToggle,
@@ -36,6 +37,7 @@ function ChangeRole({
   setRoleView,
   handleCloseSwitchView,
   roleView,
+  uid,
 }) {
   const classes = useStyles();
   const styles = isToggle ? {} : { margin: "0 10px" };
@@ -50,7 +52,12 @@ function ChangeRole({
       to={roleLandingPage}
       onClick={() => {
         setRoleView(role.key);
-        localStorage.setItem(SELECTED_ROLE_KEY, role.key);
+        // localStorage.setItem(SELECTED_ROLE_KEY, role.key);
+        const idToSelectedRoleMap = JSON.parse(
+          localStorage.getItem(ID_TO_SELECTED_ROLE_MAP_KEY)
+        ) || {};
+        idToSelectedRoleMap[uid] = role.key;
+        localStorage.setItem(ID_TO_SELECTED_ROLE_MAP_KEY, idToSelectedRoleMap);
         !isToggle && handleCloseSwitchView();
       }}
       sx={styles}
@@ -68,16 +75,20 @@ function ChangeRole({
   );
 }
 
-function ChangeRolesView({ setRole, roles, leftDrawer }) {
+function ChangeRolesView({ setRole, roles, uid, leftDrawer }) {
   const defaultRole = roles.find((role) => role.assignedRole) || roles[0];
+  const lastSelectedRoleKey = JSON.parse(
+    localStorage.getItem(ID_TO_SELECTED_ROLE_MAP_KEY)
+  )?.[uid]; // || localStorage.getItem(SELECTED_ROLE_KEY);
+  const hasLastSelectedRole = roles.some((role) => role.key === lastSelectedRoleKey);
   const [roleView, setRoleView] = React.useState(
-    localStorage.getItem(SELECTED_ROLE_KEY) || defaultRole?.key
+    hasLastSelectedRole ? lastSelectedRoleKey : defaultRole?.key
   );
   const [dropDown, setDropDown] = React.useState(null);
   const otherRole =
     roles[(roles.findIndex((role) => role.key === roleView) + 1) % 2];
 
-  const commonProps = { setRoleView, roleView };
+  const commonProps = { setRoleView, roleView, uid };
   const history = useHistory();
   //const location = useLocation();
 

--- a/src/components/Header/ChangeRolesView/index.js
+++ b/src/components/Header/ChangeRolesView/index.js
@@ -57,7 +57,10 @@ function ChangeRole({
           localStorage.getItem(ID_TO_SELECTED_ROLE_MAP_KEY)
         ) || {};
         idToSelectedRoleMap[uid] = role.key;
-        localStorage.setItem(ID_TO_SELECTED_ROLE_MAP_KEY, idToSelectedRoleMap);
+        localStorage.setItem(
+          ID_TO_SELECTED_ROLE_MAP_KEY,
+          JSON.stringify(idToSelectedRoleMap)
+        );
         !isToggle && handleCloseSwitchView();
       }}
       sx={styles}

--- a/src/components/User/redux/selectors.js
+++ b/src/components/User/redux/selectors.js
@@ -87,3 +87,9 @@ export const selectRolesData = ({ User }) => {
       }))
     );
 };
+
+/**
+ * Selector to get user id
+ * @return {string} user id
+ */
+export const selectUserId = ({ User }) => User.data.user.id;


### PR DESCRIPTION
**Which issue does this refer to ?**
https://github.com/navgurukul/bhanwari-devi/issues/659 : Prior to this fix, the navigation items that were being shown were the ones for the last selected role (in the given browser since it was being stored in `localStorage`). This could be problematic when the user had multiple accounts with different roles. Additionally, if a user lost the last selected role, it would still show the navigation items from this role.

**Brief description of the changes done**
1. Added user id selector
2. Saved the last selected role by user id. 
3. Used this user's last selected role only if they still had it.

**People to loop in / review from**
@Poonam-Singh-Bagh @vivekdogra 