### PR TITLE
Add downgraded node version 14.18.3 as dependency

### DIFF
--- a/.github/workflows/build_test_react.yml
+++ b/.github/workflows/build_test_react.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 15.x]
+        node-version: [14.x, 15.x]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "material-ui-phone-number": "^3.0.0",
     "matrix-js-sdk": "^9.4.1",
     "moment": "^2.29.1",
+    "node": "^14.18.3",
     "node-sass": "^4.14.1",
     "npm": "^6.14.10",
     "rc-slider": "^9.7.2",

--- a/src/components/VolunteerAutomation/Stepper.js
+++ b/src/components/VolunteerAutomation/Stepper.js
@@ -26,7 +26,7 @@ import ArrowForwardIosIcon from "@mui/icons-material/ArrowForwardIos";
 import SelectTrack from "./SelectTrack";
 import Confirmation from "./Confirmation";
 import AttendClass from "./AttendClass";
-import Availability from "./ Availability";
+import Availability from "./Availability";
 import CodeOfConduct from "./CodeOfConduct";
 import VerifyPhoneNo from "./VerifyPhoneNo";
 import IntroVideo from "./IntroVideo";


### PR DESCRIPTION
Testing deployment with downgraded Node version 14.18.3 as dependency (https://stackoverflow.com/a/57965993)

**Which issue does this refer to ?**
A clear and concise description. Use `#` to refer to github issues and PR

**Brief description of the changes done**
A brief step by step changes made. Example :
1. Upgraded packages
2. Added extra state to handle clicks
3. ...

**People to loop in / review from**
Use `@` key to tag people to review from