### PR TITLE
Fix/header menu hover

### DIFF
--- a/src/components/Header/DropDown.js
+++ b/src/components/Header/DropDown.js
@@ -217,6 +217,7 @@ export const DropDown = ({
       open={Boolean(indicator)}
       onClose={handleClose}
       MenuListProps={{ onMouseLeave: handleClose }}
+      hideBackdrop
     >
       {dropDown &&
         students[dropDown].map((menu, index) => {

--- a/src/components/Header/UserMenu/index.js
+++ b/src/components/Header/UserMenu/index.js
@@ -69,6 +69,7 @@ function UserMenu() {
         open={Boolean(anchorElUser)}
         onClose={handleCloseUserMenu}
         onMouseLeave={handleCloseUserMenu}
+        hideBackdrop
       >
         <NavLink to={PATHS.PROFILE} className={classes.link}>
           <MenuItem


### PR DESCRIPTION
**Which issue does this refer to ?**
#703 

**Brief description of the changes done**
Adding `hideBackdrop` property so `onMouseLeave` works (See: https://mui.com/material-ui/api/modal/#:~:text=hideBackdrop,is%20not%20rendered.) Before the backdrop modal was on top of the other menus so they wouldn't open on hover.

**People to loop in / review from**
@kartiks26 @saquibaijaz 