### PR TITLE
Allow inline styling of list

### DIFF
--- a/src/components/PathwayExercise/ContentEdit/constants.js
+++ b/src/components/PathwayExercise/ContentEdit/constants.js
@@ -31,7 +31,10 @@ export const EDITOR_JS_TOOLS = {
   inlineCode: InlineCode,
   simpleImage: SimpleImage,
   header: Header,
-  list: List,
+  list: {
+    class: List,
+    inlineToolbar: true // or ['bold', 'link']
+  }
   embed: {
     class: Embed,
     config: {

--- a/src/components/PathwayExercise/ContentEdit/constants.js
+++ b/src/components/PathwayExercise/ContentEdit/constants.js
@@ -34,7 +34,7 @@ export const EDITOR_JS_TOOLS = {
   list: {
     class: List,
     inlineToolbar: true // or ['bold', 'link']
-  }
+  },
   embed: {
     class: Embed,
     config: {


### PR DESCRIPTION
**Which issue does this refer to ?**
https://github.com/codex-team/editor.js/issues/1413#issuecomment-729863968 . Also, in the API: https://editorjs.io/enable-inline-toolbar.

https://github.com/codex-team/editor.js/blob/next/docs/tools.md

**Brief description of the changes done**
Allowed inline styling of list (e.g., highlighting text).

**People to loop in / review from**
Use `@` key to tag people to review from