### PR TITLE
Fix/don't crash on new roles or undefined message constants

### DIFF
--- a/src/common/roles.js
+++ b/src/common/roles.js
@@ -77,16 +77,16 @@ export const useRoles = () => {
   return unassignedDefaultRoles
     .map((roleKey) => ({
       key: roleKey,
-      msgKey: ROLES[roleKey]?.msgKey,
+      msgKey: ROLES[roleKey]?.msgKey || roleKey,
       assignedRole: false,
-      properties: ROLES[roleKey].properties,
+      properties: ROLES[roleKey]?.properties,
     }))
     .concat(
       rolesList.map((roleKey) => ({
         key: roleKey,
-        msgKey: ROLES[roleKey]?.msgKey,
+        msgKey: ROLES[roleKey]?.msgKey || roleKey,
         assignedRole: true,
-        properties: ROLES[roleKey].properties,
+        properties: ROLES[roleKey]?.properties,
       }))
     );
 };

--- a/src/common/roles.js
+++ b/src/common/roles.js
@@ -77,14 +77,14 @@ export const useRoles = () => {
   return unassignedDefaultRoles
     .map((roleKey) => ({
       key: roleKey,
-      msgKey: ROLES[roleKey]?.msgKey || roleKey,
+      msgKey: ROLES[roleKey]?.msgKey || roleKey[0].toUpperCase() + roleKey.substring(1),
       assignedRole: false,
       properties: ROLES[roleKey]?.properties,
     }))
     .concat(
       rolesList.map((roleKey) => ({
         key: roleKey,
-        msgKey: ROLES[roleKey]?.msgKey || roleKey,
+        msgKey: ROLES[roleKey]?.msgKey || roleKey[0].toUpperCase() + roleKey.substring(1),
         assignedRole: true,
         properties: ROLES[roleKey]?.properties,
       }))

--- a/src/components/Header/AuthenticatedHeaderOption.js
+++ b/src/components/Header/AuthenticatedHeaderOption.js
@@ -37,10 +37,12 @@ import SearchHeader from "./SearchHeader";
 import ChangeRolesView from "./ChangeRolesView";
 import { selectRolesData, selectUserId } from "../User/redux/selectors";
 
+/*
 const savedRolesToKeysMap = Object.keys(ROLES).reduce((roleKeyMap, roleKey) => {
   roleKeyMap[ROLES[roleKey].savedValue] = roleKey;
   return roleKeyMap;
 }, {});
+*/
 
 const rolesLandingPages = {
   [STUDENT]: PATHS.NEW_USER_DASHBOARD,
@@ -64,7 +66,7 @@ function AuthenticatedHeaderOption({
 
   const rolesWithLandingPages = roles.map((role) => ({
     ...role,
-    landingPage: rolesLandingPages[role.key],
+    landingPage: rolesLandingPages[role.key] || "/",
   }));
 
   // const [role, setRole] = React.useState(null);

--- a/src/components/User/redux/selectors.js
+++ b/src/components/User/redux/selectors.js
@@ -74,16 +74,16 @@ export const selectRolesData = ({ User }) => {
   return unassignedDefaultRoles
     .map((roleKey) => ({
       key: roleKey,
-      msgKey: ROLES[roleKey]?.msgKey,
+      msgKey: ROLES[roleKey]?.msgKey || roleKey[0].toUpperCase() + roleKey.substring(1),
       assignedRole: false,
-      properties: ROLES[roleKey].properties || null,
+      properties: ROLES[roleKey]?.properties || null,
     }))
     .concat(
       rolesList.map((roleKey) => ({
         key: roleKey,
-        msgKey: ROLES[roleKey]?.msgKey,
+        msgKey: ROLES[roleKey]?.msgKey || roleKey[0].toUpperCase() + roleKey.substring(1),
         assignedRole: true,
-        properties: ROLES[roleKey].properties || null,
+        properties: ROLES[roleKey]?.properties || null,
       }))
     );
 };

--- a/src/components/common/Message/index.js
+++ b/src/components/common/Message/index.js
@@ -8,13 +8,18 @@ function Message({ constantKey, children, args = [] }) {
   const key = constantKey || getTranslationKey(children);
 
   if (key) {
-    return MSG[key]?.split(/(%\d+)/g).map((part) => {
-      if (/^%\d+/.test(part) && parseInt(part.substring(1)) <= args.length) {
-        return args[parseInt(part.substring(1)) - 1];
-      } else {
-        return part;
-      }
-    });
+    if (!MSG[key]) {
+      console.warn("Message key", key, "does not exist. Using", key, ". Please update the message constants.");
+      return key;
+    } else {
+      return MSG[key]?.split(/(%\d+)/g).map((part) => {
+        if (/^%\d+/.test(part) && parseInt(part.substring(1)) <= args.length) {
+          return args[parseInt(part.substring(1)) - 1];
+        } else {
+          return part;
+        }
+      });
+    }
   } else {
     return children;
   }


### PR DESCRIPTION
**Which issue does this refer to ?**
If a new role is added and a user has that new role, the app will crash when loading the menu of roles. This happens because there is no associated object for that key so it attempts to get the values of the message/property keys on `undefined`.

Also, if a message constant is referred to that's not defined, app will crash because the `Message` component would render `undefined` in this case.

**Brief description of the changes done**
1. Use names of roles for message keys if they don't exist.
2. Use home page for landing page if the role isn't present.
3. If Message constant doesn't exist, return constant and log warning.

**People to loop in / review from**
@Poonam-Singh-Bagh 