### PR TITLE
Updated, Image rendering not up to the mark

### DIFF
--- a/src/components/PathwayExercise/ExerciseContent/index.js
+++ b/src/components/PathwayExercise/ExerciseContent/index.js
@@ -130,7 +130,15 @@ const RenderContent = ({ data, exercise }) => {
   }
   if (data.component === "image") {
     return (
-      <img className={classes.contentImage} src={data.value} alt="content" />
+      <>
+        <Box className={classes.contentImageBox}>
+          <img
+            className={classes.contentImage}
+            src={data.value}
+            alt="content"
+          />
+        </Box>
+      </>
     );
   }
   if (data.component === "youtube") {

--- a/src/components/PathwayExercise/styles.js
+++ b/src/components/PathwayExercise/styles.js
@@ -24,9 +24,16 @@ const useStyles = makeStyles((theme) => ({
     margin: "30px 0 10px 0",
   },
   contentImage: {
-    width: "100%",
     marginTop: "32px",
+    maxWidth: "100%",
   },
+  contentImageBox: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    flexWrap: "wrap",
+  },
+
   contentImg: {
     padding: 5,
     marginRight: 5,


### PR DESCRIPTION
The smaller images take up the same space as the larger images. Hence, the smaller images get stretched and are not visible properly.

![Screenshot from 2023-03-04 14-06-37](https://user-images.githubusercontent.com/42709018/222890356-1b99129e-4890-41f9-a60f-141011116bbd.png)
