### PR TITLE
Mer 365 scratch link on the dev website not clickables

### DIFF
--- a/src/components/Header/HeaderNavlink.js
+++ b/src/components/Header/HeaderNavlink.js
@@ -3,27 +3,27 @@ import useStyles from "./styles";
 
 import { Typography, MenuItem } from "@mui/material";
 import { NavLink } from "react-router-dom";
-
-function HeaderNavLink(props) {
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+function HeaderNavLink({ to, text, toggleDrawer, externalLink }) {
   const classes = useStyles();
 
   function handleLinkClick(event) {
-    if (props?.new_nav_tab) {
+    if (externalLink) {
       event.preventDefault();
-      window.open(props.to, props?.new_nav_tab ? "_blank" : "_self");
+      window.open(to, externalLink ? "_blank" : "_self");
     }
   }
 
   return (
     <MenuItem
-      onClick={props.toggleDrawer && props.toggleDrawer(false)}
+      onClick={toggleDrawer && toggleDrawer(false)}
       sx={{
         padding: 0,
         borderRadius: "8px",
       }}
     >
       <NavLink
-        to={props.to}
+        to={to}
         onClick={handleLinkClick}
         className={classes.link}
         activeClassName={classes.active}
@@ -42,8 +42,8 @@ function HeaderNavLink(props) {
             },
           }}
         >
-          {props.text}
-          {props?.icon}
+          {text}
+          {externalLink && <OpenInNewIcon style={{ color: 'Black', paddingLeft: '9px' }} />}
         </Typography>
       </NavLink>
     </MenuItem>

--- a/src/components/Header/StudentHeader/index.js
+++ b/src/components/Header/StudentHeader/index.js
@@ -5,11 +5,13 @@ import { Box, Typography, Menu, MenuItem, Button } from "@mui/material";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import ExpandLessIcon from "@mui/icons-material/ExpandLess";
 import HeaderNavLink from "../HeaderNavlink";
-import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+// import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import SearchHeader from "../SearchHeader";
 import Message from "../../common/Message";
 import { PATHS } from "../../../constant";
 import TextButtonDropDownMenu from "../TextButtonDropDownMenu";
+import ExternalLink from "../../common/ExternalLink";
+import LaunchOutlinedIcon from "@mui/icons-material/LaunchOutlined";
 import {
   LEARN_KEY,
   MENU_ITEMS,
@@ -31,13 +33,44 @@ function CommonLeftStudentHeader({ toggleDrawer }) {
         text={<Message constantKey="DASHBOARD" />}
         toggleDrawer={toggleDrawer}
       />
-      <HeaderNavLink
+      {/* <HeaderNavLink
         to={PATHS.SCRATCH}
         new_nav_tab={true}
         text={<Message constantKey="SCRATCH" />}
         toggleDrawer={toggleDrawer}
         icon={<OpenInNewIcon style={{ color: 'Black', paddingLeft: '9px' }} />}
-      />
+      /> */}
+      <MenuItem
+        toggleDrawer={toggleDrawer}
+        sx={{
+          padding: 0,
+          // borderRadius: "8px",
+        }}
+      >
+        <ExternalLink
+          href="https://www.scratch.merakilearn.org/"
+          className={classes.link}
+        >
+          {/* <Button variant="text" color="dark" className={classes.buttonLink}>
+          Scratch <LaunchOutlinedIcon sx={{ pl: "9px" }} />
+        </Button> */}
+          <Typography
+            variant="subtitle1"
+            sx={{
+              height: "36px",
+              padding: "6px 16px",
+              display: "flex",
+              alignItems: "center",
+              "&:hover": {
+                // backgroundColor: "#E9F5E9",
+                // borderRadius: "8px",
+              },
+            }}
+          >
+            Scratch <LaunchOutlinedIcon sx={{ pl: "9px" }} />
+          </Typography>
+        </ExternalLink>
+      </MenuItem>
     </>
   );
 }

--- a/src/components/Header/StudentHeader/index.js
+++ b/src/components/Header/StudentHeader/index.js
@@ -5,12 +5,10 @@ import { Box, Typography, Menu, MenuItem, Button } from "@mui/material";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import ExpandLessIcon from "@mui/icons-material/ExpandLess";
 import HeaderNavLink from "../HeaderNavlink";
-// import OpenInNewIcon from '@mui/icons-material/OpenInNew';
 import SearchHeader from "../SearchHeader";
 import Message from "../../common/Message";
 import { PATHS } from "../../../constant";
 import TextButtonDropDownMenu from "../TextButtonDropDownMenu";
-import ExternalLink from "../../common/ExternalLink";
 import LaunchOutlinedIcon from "@mui/icons-material/LaunchOutlined";
 import {
   LEARN_KEY,
@@ -24,6 +22,7 @@ import {
   // VOLUNTEER_ROLE_KEY as VOLUNTEER,
 } from "../constant";
 import SearchPopup from "../../SearchBar/SearchPopup";
+import ExternalLink from "../../common/ExternalLink";
 
 function CommonLeftStudentHeader({ toggleDrawer }) {
   return (
@@ -33,44 +32,12 @@ function CommonLeftStudentHeader({ toggleDrawer }) {
         text={<Message constantKey="DASHBOARD" />}
         toggleDrawer={toggleDrawer}
       />
-      {/* <HeaderNavLink
+      <HeaderNavLink
         to={PATHS.SCRATCH}
-        new_nav_tab={true}
         text={<Message constantKey="SCRATCH" />}
         toggleDrawer={toggleDrawer}
-        icon={<OpenInNewIcon style={{ color: 'Black', paddingLeft: '9px' }} />}
-      /> */}
-      <MenuItem
-        toggleDrawer={toggleDrawer}
-        sx={{
-          padding: 0,
-          // borderRadius: "8px",
-        }}
-      >
-        <ExternalLink
-          href="https://www.scratch.merakilearn.org/"
-          className={classes.link}
-        >
-          {/* <Button variant="text" color="dark" className={classes.buttonLink}>
-          Scratch <LaunchOutlinedIcon sx={{ pl: "9px" }} />
-        </Button> */}
-          <Typography
-            variant="subtitle1"
-            sx={{
-              height: "36px",
-              padding: "6px 16px",
-              display: "flex",
-              alignItems: "center",
-              "&:hover": {
-                // backgroundColor: "#E9F5E9",
-                // borderRadius: "8px",
-              },
-            }}
-          >
-            Scratch <LaunchOutlinedIcon sx={{ pl: "9px" }} />
-          </Typography>
-        </ExternalLink>
-      </MenuItem>
+        externalLink="true"
+      />
     </>
   );
 }


### PR DESCRIPTION
When the student logs in, in the NavBar he/she can see Scratch option.
That option is not clickable.


1. Now , Scratch link is working
2. Added icon for new tab and Added some changes like remove props from every place
![image](https://user-images.githubusercontent.com/117170277/224019399-ba249840-2ede-4769-b073-24d3bbb60e98.png)


@amansharmma 