### PR TITLE
fix: Don't have responses from `/pathways` and `/pathways/dropdown` overwrite each other in Redux state

### DIFF
--- a/src/components/PathwayCourse/redux/reducer.js
+++ b/src/components/PathwayCourse/redux/reducer.js
@@ -155,7 +155,7 @@ export const Pathways = (state = initialState, action) => {
   }
 };
 
-export const PathwayDropdown = (state = initialState, action) => {
+export const PathwaysDropdown = (state = initialState, action) => {
   switch (action.type) {
     // getPathwaysDropdown
     case types.GET_PATHWAY_DROPDOWN_INTENT:

--- a/src/components/PathwayCourse/redux/reducer.js
+++ b/src/components/PathwayCourse/redux/reducer.js
@@ -6,7 +6,7 @@ const initialState = {
   data: null,
 };
 
-export const Pathway = (state = initialState, action) => {
+export const Pathways = (state = initialState, action) => {
   switch (action.type) {
     case types.GET_PATHWAY_INTENT:
       return {

--- a/src/components/PathwayCourse/redux/reducer.js
+++ b/src/components/PathwayCourse/redux/reducer.js
@@ -6,7 +6,7 @@ const initialState = {
   data: null,
 };
 
-export default (state = initialState, action) => {
+export const Pathway = (state = initialState, action) => {
   switch (action.type) {
     case types.GET_PATHWAY_INTENT:
       return {
@@ -23,30 +23,6 @@ export default (state = initialState, action) => {
         data: action.data,
       };
     case types.GET_PATHWAY_INTENT_REJECTED:
-      return {
-        ...state,
-        loading: false,
-        error: action.error,
-        data: null,
-      };
-
-    // getPathwaysDropdown
-
-    case types.GET_PATHWAY_DROPDOWN_INTENT:
-      return {
-        ...state,
-        loading: true,
-        error: false,
-        data: null,
-      };
-    case types.GET_PATHWAY_DROPDOWN_INTENT_RESOLVED:
-      return {
-        ...state,
-        loading: false,
-        error: false,
-        data: action.data,
-      };
-    case types.GET_PATHWAY_DROPDOWN_INTENT_REJECTED:
       return {
         ...state,
         loading: false,
@@ -178,3 +154,32 @@ export default (state = initialState, action) => {
       return state;
   }
 };
+
+export const PathwayDropdown = (state = initialState, action) => {
+  switch (action.type) {
+    // getPathwaysDropdown
+    case types.GET_PATHWAY_DROPDOWN_INTENT:
+      return {
+        ...state,
+        loading: true,
+        error: false,
+        data: null,
+      };
+    case types.GET_PATHWAY_DROPDOWN_INTENT_RESOLVED:
+      return {
+        ...state,
+        loading: false,
+        error: false,
+        data: action.data,
+      };
+    case types.GET_PATHWAY_DROPDOWN_INTENT_REJECTED:
+      return {
+        ...state,
+        loading: false,
+        error: action.error,
+        data: null,
+      };
+    default:
+      return state;
+  }
+}

--- a/src/rootReducer.js
+++ b/src/rootReducer.js
@@ -5,7 +5,7 @@ import { types as appTypes } from "./components/App/redux/action";
 import User from "./components/User/redux/reducer";
 import Class from "./components/Class/redux/reducer";
 import Course from "./components/Course/redux/reducer";
-import { Pathways, PathwaysDropdow } from "./components/PathwayCourse/redux/reducer";
+import { Pathways, PathwaysDropdown as PathwaysDropdow } from "./components/PathwayCourse/redux/reducer";
 
 // import Notifications from './Notifications'
 

--- a/src/rootReducer.js
+++ b/src/rootReducer.js
@@ -5,8 +5,7 @@ import { types as appTypes } from "./components/App/redux/action";
 import User from "./components/User/redux/reducer";
 import Class from "./components/Class/redux/reducer";
 import Course from "./components/Course/redux/reducer";
-import Pathways from "./components/PathwayCourse/redux/reducer";
-import PathwaysDropdow from "./components/PathwayCourse/redux/reducer";
+import { Pathways, PathwaysDropdow } from "./components/PathwayCourse/redux/reducer";
 
 // import Notifications from './Notifications'
 


### PR DESCRIPTION
**Which issue does this refer to ?**
Responses from `GET /pathways` and `GET /pathways/dropdown` are currently being stored in the same places in the slices of Redux state causing one to overwrite the other.

**Brief description of the changes done**
A brief step by step changes made. Example :
1. Split the single reducer into two and updated the exports.
2. Updated the import in the root reducer, accordingly to use these two different reducers, so they're stored in different slices of state.

**Didn't check other pieces of reliant code or test, so this may have caused issues**

**People to loop in / review from**
Use `@` key to tag people to review from