### PR TITLE
Perf/Prevent some repeat API requests

### DIFF
--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -1,8 +1,10 @@
-import React from "react";
+import React, { useEffect } from "react";
 import Routing from "../../routing";
 import Header from "../Header";
 import Footer from "../Footer";
 import { useRouteMatch } from "react-router-dom";
+import { useSelector, useDispatch } from "react-redux";
+import { actions as pathwayActions } from "../PathwayCourse/redux/action";
 import { HideHeader, HideFooter } from "../../constant";
 import { ThemeProvider } from "@mui/material/styles";
 import { LanguageProvider } from "../../common/context";
@@ -20,6 +22,17 @@ function App() {
   const showFooter = !useRouteMatch({
     path: HideFooter,
   });
+
+  const user = useSelector(({ User }) => User);
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(
+      pathwayActions.getPathwaysDropdown({
+        authToken: user,
+      })
+    );
+  }, [dispatch, user]);
 
   return (
     <LanguageProvider.Provider

--- a/src/components/Footer/index.js
+++ b/src/components/Footer/index.js
@@ -45,13 +45,13 @@ const MenuList = (menuItem) => {
     return state.PathwaysDropdow;
   });
 
-  useEffect(() => {
-    dispatch(
-      pathwayActions.getPathwaysDropdown({
-        authToken: user,
-      })
-    );
-  }, [dispatch, user]);
+  // useEffect(() => {
+  //   dispatch(
+  //     pathwayActions.getPathwaysDropdown({
+  //       authToken: user,
+  //     })
+  //   );
+  // }, [dispatch, user]);
 
   const miscellaneousPathway = data?.pathways.filter((pathway) =>
     PATHWAYS_INFO.some((miscPathway) => pathway.name === miscPathway.name)
@@ -152,13 +152,13 @@ function Footer() {
 
   const isActive = useMediaQuery("(max-width:" + breakpoints.values.sm + "px)");
 
-  useEffect(() => {
-    dispatch(
-      pathwayActions.getPathwaysDropdown({
-        authToken: user,
-      })
-    );
-  }, [dispatch, user]);
+  // useEffect(() => {
+  //   dispatch(
+  //     pathwayActions.getPathwaysDropdown({
+  //       authToken: user,
+  //     })
+  //   );
+  // }, [dispatch, user]);
 
   menu.LearningTracks &&
     data &&

--- a/src/components/Header/DropDown.js
+++ b/src/components/Header/DropDown.js
@@ -60,13 +60,13 @@ export const MobileDropDown = ({ menuKey, handleClose, toggleDrawer }) => {
   const { data } = useSelector((state) => state.PathwaysDropdow);
   // const { language, MSG } = useLanguageConstants(); //useContext(LanguageProvider);
 
-  useEffect(() => {
-    dispatch(
-      pathwayActions.getPathwaysDropdown({
-        authToken: user,
-      })
-    );
-  }, [dispatch, user]);
+  // useEffect(() => {
+  //   dispatch(
+  //     pathwayActions.getPathwaysDropdown({
+  //       authToken: user,
+  //     })
+  //   );
+  // }, [dispatch, user]);
 
   const miscellaneousPathway = data?.pathways.filter((pathway) =>
     PATHWAYS_INFO.some((miscPathway) => pathway.name === miscPathway.name)
@@ -157,13 +157,13 @@ export const DropDown = ({
   const dispatch = useDispatch();
   const { data } = useSelector((state) => state.PathwaysDropdow);
 
-  useEffect(() => {
-    dispatch(
-      pathwayActions.getPathwaysDropdown({
-        authToken: user,
-      })
-    );
-  }, [dispatch, user]);
+  // useEffect(() => {
+  //   dispatch(
+  //     pathwayActions.getPathwaysDropdown({
+  //       authToken: user,
+  //     })
+  //   );
+  // }, [dispatch, user]);
 
   return (
     <>

--- a/src/components/NewUserDashbord/index.js
+++ b/src/components/NewUserDashbord/index.js
@@ -22,13 +22,13 @@ const NewUserDashbord = () => {
 
  
 
-  useEffect(() => {
-    dispatch(
-      pathwayActions.getPathwaysDropdown({
-        authToken: user,
-      })
-    );
-  }, [dispatch, user]);
+  // useEffect(() => {
+  //   dispatch(
+  //     pathwayActions.getPathwaysDropdown({
+  //       authToken: user,
+  //     })
+  //   );
+  // }, [dispatch, user]);
 
   useEffect(() => {
     axios({

--- a/src/components/PathwayCourse/index.js
+++ b/src/components/PathwayCourse/index.js
@@ -216,7 +216,8 @@ function PathwayCourse() {
         setisFormFilled(response.data);
       })
       .catch((err) => {});
-  }, [pathwayId, pathwayCourse]);
+//  }, [pathwayId, pathwayCourse]);
+    }, []);
 
   useEffect(() => {
     if (user?.data?.token && pathwayId) {

--- a/src/components/PathwayCourse/redux/saga.js
+++ b/src/components/PathwayCourse/redux/saga.js
@@ -95,12 +95,12 @@ function* handleGetEnrolledBatches({ data }) {
   }
 }
 
-export default function* () {
+export function* Pathways() {
   yield takeLatest(types.GET_PATHWAY_INTENT, handleGetPathways);
-  yield takeLatest(
-    types.GET_PATHWAY_DROPDOWN_INTENT,
-    handleGetPathwaysDropdown
-  );
+  // yield takeLatest(
+  //   types.GET_PATHWAY_DROPDOWN_INTENT,
+  //   handleGetPathwaysDropdown
+  // );
   yield takeLatest(types.GET_PATHWAY_COURSE_INTENT, handleGetPathwaysCourse);
   yield takeLatest(types.GET_UPCOMING_BATCHES_INTENT, handleGetUpcomingBatches);
   yield takeLatest(
@@ -108,4 +108,11 @@ export default function* () {
     handleGetUpcomingEnrolledClasses
   );
   yield takeLatest(types.GET_ENROLLED_BATCHES_INTENT, handleGetEnrolledBatches);
+}
+
+export function* PathwaysDropdown() {
+  yield takeLatest(
+    types.GET_PATHWAY_DROPDOWN_INTENT,
+    handleGetPathwaysDropdown
+  );
 }

--- a/src/components/ReturningUser/LearningTrackCard.js
+++ b/src/components/ReturningUser/LearningTrackCard.js
@@ -39,13 +39,14 @@ import { InsertEmoticonRounded } from "@mui/icons-material";
 
 function LearningTrackCard(props) {
   const user = useSelector(({ User }) => User);
+  // const pathwaysData = useSelector(({ Pathways }) => Pathways);
   const dispatch = useDispatch();
   const isActive = useMediaQuery("(max-width:" + breakpoints.values.sm + "px)");
-  const isActiveIpad = useMediaQuery("(max-width:1300px)");
+  // const isActiveIpad = useMediaQuery("(max-width:1300px)");
   const classes = useStyles();
   const history = useHistory();
-  const [PathwayData, setPathwayData] = useState([]);
-  const [courseIndex, setCourseIndex] = useState(0);
+  // const [PathwayData, setPathwayData] = useState([]);
+  // const [courseIndex, setCourseIndex] = useState(0);
   const [open, setOpen] = React.useState(false);
   const { item, setPathway } = props;
   const pathwayId = item.pathway_id;
@@ -53,18 +54,18 @@ function LearningTrackCard(props) {
   const [upcomingBatchesData, setUpcomingBatchesData] = useState();
   const params = useParams();
 
-  useEffect(() => {
-    getPathwaysCourse({ pathwayId: pathwayId }).then((res) => {
-      setPathwayData(res.data);
-    });
+  // useEffect(() => {
+  //   getPathwaysCourse({ pathwayId: pathwayId }).then((res) => {
+  //     setPathwayData(res.data);
+  //   });
 
-    const COurseIndex = PathwayData?.courses?.findIndex((course, index) => {
-      if (course.course_id === item.course_id) {
-        return index;
-      }
-    });
-    setCourseIndex(COurseIndex);
-  }, [item]);
+  //   const COurseIndex = PathwayData?.courses?.findIndex((course, index) => {
+  //     if (course.course_id === item.course_id) {
+  //       return index;
+  //     }
+  //   });
+  //   setCourseIndex(COurseIndex);
+  // }, [item]);
 
   const data = useSelector((state) => {
     return state;
@@ -92,9 +93,9 @@ function LearningTrackCard(props) {
     }
   }, [pathwayId]);
 
-  useEffect(() => {
-    dispatch(pathwayActions.getPathwaysCourse({ pathwayId: pathwayId }));
-  }, [dispatch, pathwayId]);
+  // useEffect(() => {
+  //   dispatch(pathwayActions.getPathwaysCourse({ pathwayId: pathwayId }));
+  // }, [dispatch, pathwayId]);
 
   useEffect(() => {
     axios({

--- a/src/components/ReturningUser/LearningTrackCard.js
+++ b/src/components/ReturningUser/LearningTrackCard.js
@@ -74,12 +74,12 @@ function LearningTrackCard(props) {
   useEffect(() => {
     // setLoading(true);
     if (user?.data?.token && pathwayId) {
-      dispatch(
-        enrolledBatchesActions.getEnrolledBatches({
-          pathwayId: pathwayId,
-          authToken: user?.data?.token,
-        })
-      );
+      // dispatch(
+      //   enrolledBatchesActions.getEnrolledBatches({
+      //     pathwayId: pathwayId,
+      //     authToken: user?.data?.token,
+      //   })
+      // );
       axios({
         method: METHODS.GET,
         url: `${process.env.REACT_APP_MERAKI_URL}/pathways/${pathwayId}/completePortion`,
@@ -98,24 +98,35 @@ function LearningTrackCard(props) {
   // }, [dispatch, pathwayId]);
 
   useEffect(() => {
-    axios({
-      method: METHODS.GET,
-      url: `${process.env.REACT_APP_MERAKI_URL}/pathways/${pathwayId}/upcomingBatches`,
-      headers: {
-        accept: "application/json",
-        Authorization: user?.data?.token,
-      },
-    }).then((res) => {
-      setUpcomingBatchesData(res.data);
-    });
+    if (showUpcomingBatchData) {
+      axios({
+        method: METHODS.GET,
+        url: `${process.env.REACT_APP_MERAKI_URL}/pathways/${pathwayId}/upcomingBatches`,
+        headers: {
+          accept: "application/json",
+          Authorization: user?.data?.token,
+        },
+      }).then((res) => {
+        setUpcomingBatchesData(res.data);
+      });
+    }
   }, []);
   // const upcomingBatchesData = useSelector((state) => {
   //   return state.Pathways?.upcomingBatches?.data;
   // });
 
-  const pathwayCourseData = data.Pathways?.data?.pathways.find((item) => {
+  // useEffect(() => {
+  //   dispatch(pathwayActions.getPathways());
+  // }, [dispatch, pathwayId]);
+
+  const pathwayCourseData = data.PathwaysDropdow?.data?.pathways.find((item) => {
     return item.id == pathwayId;
   });
+
+  const showUpcomingBatchData = 
+    pathwayCourseData?.code == 'PRGPYT' || pathwayCourseData?.code == 'SPKENG';
+
+  // console.log(data, pathwayId, showUpcomingBatchData);
 
   return (
     <>
@@ -169,8 +180,7 @@ function LearningTrackCard(props) {
             </Grid>
           </Grid>
 
-          {(pathwayCourseData?.code == "PRGPYT" ||
-            pathwayCourseData?.code == "SPKENG") &&
+          {showUpcomingBatchData &&
             upcomingBatchesData?.length > 0 && (
               <>
                 <Typography variant="subtitle1" mb={2} mt={2}>

--- a/src/pages/Profile/CertificateCard.js
+++ b/src/pages/Profile/CertificateCard.js
@@ -64,9 +64,9 @@ function CertificateCard(props) {
   const options = { day: "numeric", month: "short", year: "2-digit" };
   const formattedDate = date.toLocaleDateString("en-US", options);
 
-  useEffect(() => {
-    dispatch(pathwayActions.getPathwaysCourse({ pathwayId: pathwayId }));
-  }, [dispatch, pathwayId]);
+  // useEffect(() => {
+  //   dispatch(pathwayActions.getPathwaysCourse({ pathwayId: pathwayId }));
+  // }, [dispatch, pathwayId]);
   const modalStyle = {
     position: "absolute",
     top: "50%",
@@ -79,9 +79,9 @@ function CertificateCard(props) {
     boxShadow: 24,
     p: 4,
   };
-  useEffect(() => {
-    dispatch(pathwayActions.getPathwaysCourse({ pathwayId: pathwayId }));
-  }, [dispatch, pathwayId]);
+  // useEffect(() => {
+  //   dispatch(pathwayActions.getPathwaysCourse({ pathwayId: pathwayId }));
+  // }, [dispatch, pathwayId]);
   useEffect(() => {
     // setLoading(true);
     if (user?.data?.token && pathwayId) {

--- a/src/pages/Profile/CertificateCard.js
+++ b/src/pages/Profile/CertificateCard.js
@@ -15,7 +15,7 @@ import axios from "axios";
 import { METHODS } from "../../services/api";
 import { useSelector, useDispatch } from "react-redux";
 import { useParams } from "react-router-dom";
-import { actions as enrolledBatchesActions } from "../../components/PathwayCourse/redux/action";
+// import { actions as enrolledBatchesActions } from "../../components/PathwayCourse/redux/action";
 import { actions as pathwayActions } from "../../components/PathwayCourse/redux/action";
 import { PATHS, versionCode } from "../../constant";
 import { Link } from "react-router-dom";
@@ -43,9 +43,9 @@ function saveFile(url) {
 function CertificateCard(props) {
   const classes = useStyles();
   const user = useSelector(({ User }) => User);
-  const data = useSelector((state) => {
-    return state;
-  });
+  // const data = useSelector((state) => {
+  //   return state;
+  // });
   const { item } = props;
 
   const dispatch = useDispatch();
@@ -85,12 +85,12 @@ function CertificateCard(props) {
   useEffect(() => {
     // setLoading(true);
     if (user?.data?.token && pathwayId) {
-      dispatch(
-        enrolledBatchesActions.getEnrolledBatches({
-          pathwayId: pathwayId,
-          authToken: user?.data?.token,
-        })
-      );
+      // dispatch(
+      //   enrolledBatchesActions.getEnrolledBatches({
+      //     pathwayId: pathwayId,
+      //     authToken: user?.data?.token,
+      //   })
+      // );
       axios({
         method: METHODS.GET,
         url: `${process.env.REACT_APP_MERAKI_URL}/pathways/${pathwayId}/completePortion`,

--- a/src/pages/Profile/UnlockOpportunities.js
+++ b/src/pages/Profile/UnlockOpportunities.js
@@ -23,9 +23,9 @@ import { Link } from "react-router-dom";
 import LockOpenIcon from "@mui/icons-material/LockOpen";
 function UnlockOpportunities(props) {
   const user = useSelector(({ User }) => User);
-  const data = useSelector((state) => {
-    return state;
-  });
+  // const data = useSelector((state) => {
+  //   return state;
+  // });
 
   const { item } = props;
 
@@ -39,18 +39,18 @@ function UnlockOpportunities(props) {
   const params = useParams();
   const pathwayId = item.id;
 
-  useEffect(() => {
-    dispatch(pathwayActions.getPathwaysCourse({ pathwayId: pathwayId }));
-  }, [dispatch, pathwayId]);
+  // useEffect(() => {
+  //   dispatch(pathwayActions.getPathwaysCourse({ pathwayId: pathwayId }));
+  // }, [dispatch, pathwayId]);
   useEffect(() => {
     // setLoading(true);
     if (user?.data?.token && pathwayId) {
-      dispatch(
-        enrolledBatchesActions.getEnrolledBatches({
-          pathwayId: pathwayId,
-          authToken: user?.data?.token,
-        })
-      );
+      // dispatch(
+      //   enrolledBatchesActions.getEnrolledBatches({
+      //     pathwayId: pathwayId,
+      //     authToken: user?.data?.token,
+      //   })
+      // );
       axios({
         method: METHODS.GET,
         url: `${process.env.REACT_APP_MERAKI_URL}/pathways/${pathwayId}/completePortion`,

--- a/src/rootSaga.js
+++ b/src/rootSaga.js
@@ -3,8 +3,8 @@ import { fork, all } from "redux-saga/effects";
 import User from "./components/User/redux/saga";
 import Class from "./components/Class/redux/saga";
 import Course from "./components/Course/redux/saga";
-import Pathways from "./components/PathwayCourse/redux/saga";
-import PathwaysDropdow from "./components/PathwayCourse/redux/saga";
+import { Pathways, PathwaysDropdown } from "./components/PathwayCourse/redux/saga";
+// import PathwaysDropdow from "./components/PathwayCourse/redux/saga";
 // import Notifications from './Notifications'
 
 export default function* () {
@@ -13,6 +13,6 @@ export default function* () {
     fork(Class),
     fork(Course),
     fork(Pathways),
-    fork(PathwaysDropdow),
+    fork(PathwaysDropdown),
   ]);
 }


### PR DESCRIPTION
**Which issue does this refer to ?**
Removes unnecessary (repeat) requests to `/pathways/dropdown`, `/pathways/{pathwayId}/courses`, and `teacher/checking`.

**Brief description of the changes done**
1. Moved action dispatch to make API requests to `/pathways/dropdown` from Header and Footer, to parent `App` component. 
2. Split pathway saga generator function into two: one to handle the `GET_PATHWAY_DROPDOWN_INTENT` actions that are dispatched, and one for all the others. Then we could import them separately for use in the root saga to avoid the double requests for each action resulting from forking the same function twice. 
3. Removed unnecessary dispatches/API requests that would unnecessarily call `/pathways/{pathwayId}/courses` where the data wasn't being used.
4. Removed unnecessary dependencies in `useEffect` with function making API request to `teacher/checking` that caused unnecessary repeats of this API request.

**People to loop in / review from**
@komalahire 