### PR TITLE
fixed routing issue with already registered ACB student

### DIFF
--- a/src/pages/Login/index.js
+++ b/src/pages/Login/index.js
@@ -69,10 +69,19 @@ function Login(props) {
     pathway.data.pathways.find((pathway) => pathway.code === "PRGPYT");
   const pythonPathwayId = pythonPathway && pythonPathway.id;
 
+  // PathwayId for Amazon Pathway:-
   const amazonPathway =
     pathway.data &&
     pathway.data.pathways.find((pathway) => pathway.code === "ACB");
-  const amazonPathwayId = amazonPathway && amazonPathway.id;
+  const [amazonPathwayId, setAmazonPathwayId] = useState(null);
+
+  useEffect(() => {
+    if(amazonPathwayId == null){
+      setAmazonPathwayId(amazonPathway && amazonPathway.id)
+    }
+  }, [user]);
+
+  // ---------------------------------------------
 
   const rolesLandingPages = {
     volunteer: PATHS.CLASS,


### PR DESCRIPTION
**Which issue does this refer to ?**
fixed routing issue with already registered ACB student

**Brief description of the changes done**
The routing of Already registered ACB students was not happening as pathwayId for amazon was not getting stored hence added condition and stored pathwayId in a state. Now the routing is working fine
Below file code modified:-
src>pages>Login>index.js
**People to loop in / review from**
Use `@` key to tag people to review from